### PR TITLE
Profile dashboards: editor, streak, coach quick-stats, history

### DIFF
--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -1,3 +1,6 @@
+# Local dev env (--dart-define-from-file). Contains DEV_PASSWORD.
+dev-env.json
+
 # Miscellaneous
 *.class
 *.log

--- a/mobile/lib/design/spacing.dart
+++ b/mobile/lib/design/spacing.dart
@@ -1,0 +1,20 @@
+/// Velofit spacing scale — 4pt grid, geometric progression.
+/// Use these instead of raw pixel values for consistent visual rhythm.
+class AppSpacing {
+  const AppSpacing._();
+
+  static const double xxs = 4;
+  static const double xs = 8;
+  static const double sm = 12;
+  static const double md = 16;
+  static const double lg = 24;
+  static const double xl = 32;
+  static const double xxl = 48;
+
+  /// Corner radius scale — also 4pt-based.
+  static const double radiusSm = 8;
+  static const double radiusMd = 12;
+  static const double radiusLg = 16;
+  static const double radiusXl = 20;
+  static const double radiusPill = 999;
+}

--- a/mobile/lib/design/widgets.dart
+++ b/mobile/lib/design/widgets.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+
+import '../theme.dart';
+import 'spacing.dart';
+
+/// Small uppercase-ish caption used above a data block.
+/// Establishes hierarchy without competing with content (Tufte: minimal ornament).
+class SectionHeader extends StatelessWidget {
+  final String text;
+  const SectionHeader(this.text, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              color: BrandColors.inkSoft,
+              letterSpacing: 0.4,
+              fontWeight: FontWeight.w700,
+            ),
+      ),
+    );
+  }
+}
+
+/// Label/value row aligned to a 24px gutter on the leading edge.
+/// Replaces the icon+label+value pattern that was duplicated 3+ places.
+/// Empty `value` is shown as a muted "חסר" inline placeholder.
+class InfoRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String? value;
+  final String? emptyText;
+
+  const InfoRow({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.value,
+    this.emptyText = 'חסר',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isEmpty = value == null || value!.isEmpty;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 18, color: BrandColors.inkSoft),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(label,
+                    style: theme.textTheme.labelSmall?.copyWith(
+                          color: BrandColors.inkSoft,
+                        )),
+                const SizedBox(height: 2),
+                Text(
+                  isEmpty ? emptyText! : value!,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                        color: isEmpty ? BrandColors.inkMuted : BrandColors.ink,
+                        fontStyle: isEmpty ? FontStyle.italic : FontStyle.normal,
+                      ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 2-column data grid for short label/value pairs (e.g., גובה/משקל/גיל).
+class DataGrid extends StatelessWidget {
+  final List<InfoRow> children;
+  const DataGrid({super.key, required this.children});
+
+  @override
+  Widget build(BuildContext context) {
+    final pairs = <Widget>[];
+    for (var i = 0; i < children.length; i += 2) {
+      pairs.add(
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(child: children[i]),
+            const SizedBox(width: AppSpacing.md),
+            Expanded(
+              child: i + 1 < children.length
+                  ? children[i + 1]
+                  : const SizedBox.shrink(),
+            ),
+          ],
+        ),
+      );
+    }
+    return Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: pairs);
+  }
+}
+
+/// Soft, brand-tinted container — replaces the heavy translucent glass on hero stats.
+/// Use over the gradient hero only.
+class HeroStat extends StatelessWidget {
+  final String value;
+  final String label;
+  final IconData? icon;
+  final Color? accent;
+
+  const HeroStat({
+    super.key,
+    required this.value,
+    required this.label,
+    this.icon,
+    this.accent,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final accentColor = accent ?? Colors.white;
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.sm,
+          AppSpacing.xs,
+          AppSpacing.sm,
+          AppSpacing.sm,
+        ),
+        decoration: BoxDecoration(
+          color: Colors.white.withValues(alpha: 0.10),
+          borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+          border: Border(
+            top: BorderSide(color: accentColor.withValues(alpha: 0.8), width: 3),
+          ),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (icon != null) ...[
+              Icon(icon, size: 14, color: Colors.white.withValues(alpha: 0.85)),
+              const SizedBox(height: AppSpacing.xxs),
+            ],
+            Text(
+              value,
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w800,
+                    height: 1.05,
+                  ),
+            ),
+            Text(
+              label,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: Colors.white.withValues(alpha: 0.85),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Status leading-stripe — replaces CircleAvatar+icon for list status indicators.
+/// 3px vertical bar in the status color, no chrome.
+class StatusStripeTile extends StatelessWidget {
+  final Color stripeColor;
+  final Widget title;
+  final Widget? subtitle;
+  final Widget? trailing;
+
+  const StatusStripeTile({
+    super.key,
+    required this.stripeColor,
+    required this.title,
+    this.subtitle,
+    this.trailing,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.md,
+        vertical: AppSpacing.sm,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Container(
+            width: 3,
+            height: 36,
+            decoration: BoxDecoration(
+              color: stripeColor,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                title,
+                if (subtitle != null) ...[
+                  const SizedBox(height: 2),
+                  subtitle!,
+                ],
+              ],
+            ),
+          ),
+          if (trailing != null) ...[
+            const SizedBox(width: AppSpacing.sm),
+            trailing!,
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/coach/change_requests_repository.dart
+++ b/mobile/lib/features/coach/change_requests_repository.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../utils/authed_http_client.dart';
+
+class ChangeRequest {
+  final String id;
+  final String requestedAt;
+  final String reason;
+  final String traineeId;
+  final String traineeName;
+  final String fromSlotStartsAt; // ISO
+  final String? toSlotStartsAt; // ISO; null = cancel request
+
+  const ChangeRequest({
+    required this.id,
+    required this.requestedAt,
+    required this.reason,
+    required this.traineeId,
+    required this.traineeName,
+    required this.fromSlotStartsAt,
+    required this.toSlotStartsAt,
+  });
+
+  bool get isCancelRequest => toSlotStartsAt == null;
+
+  factory ChangeRequest.fromJson(Map<String, dynamic> json) {
+    final trainee = json['trainee'] as Map<String, dynamic>;
+    final from = json['fromSlot'] as Map<String, dynamic>;
+    final to = json['toSlot'] as Map<String, dynamic>?;
+    return ChangeRequest(
+      id: json['id'] as String,
+      requestedAt: json['requestedAt'] as String,
+      reason: (json['reason'] as String?) ?? '',
+      traineeId: trainee['id'] as String,
+      traineeName: trainee['name'] as String,
+      fromSlotStartsAt: from['startsAt'] as String,
+      toSlotStartsAt: to?['startsAt'] as String?,
+    );
+  }
+}
+
+abstract class ChangeRequestsRepository {
+  Future<List<ChangeRequest>> fetch();
+  Future<void> decide(String id, {required String decision, String? note});
+}
+
+class HttpChangeRequestsRepository implements ChangeRequestsRepository {
+  final AuthedHttpClient _http;
+  HttpChangeRequestsRepository(this._http);
+
+  @override
+  Future<List<ChangeRequest>> fetch() async {
+    final json =
+        await _http.get<Map<String, dynamic>>('/api/admin/change-requests');
+    final list = (json['requests'] as List).cast<Map<String, dynamic>>();
+    return list.map(ChangeRequest.fromJson).toList();
+  }
+
+  @override
+  Future<void> decide(String id, {required String decision, String? note}) async {
+    final body = <String, dynamic>{'decision': decision};
+    if (note != null) body['note'] = note;
+    await _http.post<void>('/api/admin/change-requests/$id/decide', data: body);
+  }
+}
+
+final changeRequestsRepositoryProvider =
+    Provider<ChangeRequestsRepository>((ref) {
+  return HttpChangeRequestsRepository(ref.watch(authedHttpProvider));
+});
+
+final changeRequestsProvider = FutureProvider<List<ChangeRequest>>((ref) {
+  return ref.watch(changeRequestsRepositoryProvider).fetch();
+});

--- a/mobile/lib/features/coach/change_requests_screen.dart
+++ b/mobile/lib/features/coach/change_requests_screen.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'change_requests_repository.dart';
+
+class ChangeRequestsScreen extends ConsumerWidget {
+  const ChangeRequestsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(changeRequestsProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('בקשות שינוי')),
+      body: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, _) => Center(
+          child: Text('שגיאה: $err', key: const Key('change-requests-error')),
+        ),
+        data: (requests) {
+          if (requests.isEmpty) {
+            return const Center(
+              key: Key('change-requests-empty'),
+              child: Text('אין בקשות שינוי פתוחות'),
+            );
+          }
+          return RefreshIndicator(
+            onRefresh: () async => ref.invalidate(changeRequestsProvider),
+            child: ListView.separated(
+              itemCount: requests.length,
+              separatorBuilder: (_, _) => const Divider(height: 1),
+              itemBuilder: (_, i) => _RequestTile(request: requests[i]),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _RequestTile extends ConsumerStatefulWidget {
+  final ChangeRequest request;
+  const _RequestTile({required this.request});
+
+  @override
+  ConsumerState<_RequestTile> createState() => _RequestTileState();
+}
+
+class _RequestTileState extends ConsumerState<_RequestTile> {
+  bool _busy = false;
+
+  Future<void> _decide(String decision) async {
+    setState(() => _busy = true);
+    try {
+      await ref.read(changeRequestsRepositoryProvider).decide(
+            widget.request.id,
+            decision: decision,
+          );
+      ref.invalidate(changeRequestsProvider);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(decision == 'approve' ? 'אושר' : 'נדחה')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('שגיאה: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final r = widget.request;
+    return Padding(
+      key: Key('cr-tile-${r.id}'),
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              CircleAvatar(
+                backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+                child: Text(r.traineeName.characters.first),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(r.traineeName,
+                        style: Theme.of(context).textTheme.titleMedium),
+                    Text(
+                      r.isCancelRequest
+                          ? 'בקשת ביטול: ${_fmt(r.fromSlotStartsAt)}'
+                          : 'בקשת העברה: ${_fmt(r.fromSlotStartsAt)} → ${_fmt(r.toSlotStartsAt!)}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (r.reason.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Container(
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(r.reason),
+            ),
+          ],
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              Expanded(
+                child: FilledButton.tonal(
+                  key: Key('reject-${r.id}'),
+                  onPressed: _busy ? null : () => _decide('reject'),
+                  child: const Text('דחה'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: FilledButton(
+                  key: Key('approve-${r.id}'),
+                  onPressed: _busy ? null : () => _decide('approve'),
+                  child: const Text('אישור'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _fmt(String iso) {
+    final d = DateTime.parse(iso).toLocal();
+    final hh = d.hour.toString().padLeft(2, '0');
+    final mm = d.minute.toString().padLeft(2, '0');
+    return '${d.day}.${d.month} $hh:$mm';
+  }
+}

--- a/mobile/lib/features/coach/coach_about_card.dart
+++ b/mobile/lib/features/coach/coach_about_card.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'coach_info_repository.dart';
+
+class CoachAboutCard extends ConsumerWidget {
+  const CoachAboutCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(coachInfoProvider);
+    return async.maybeWhen(
+      orElse: () => const SizedBox.shrink(),
+      data: (info) {
+        if (info == null) return const SizedBox.shrink();
+        final hasContent =
+            info.bio != null || info.specialty != null || info.yearsExperience != null;
+        if (!hasContent) return const SizedBox.shrink();
+
+        final theme = Theme.of(context);
+        return Padding(
+          key: const Key('coach-about-card'),
+          padding: const EdgeInsets.fromLTRB(16, 14, 16, 0),
+          child: Card(
+            elevation: 0,
+            color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      CircleAvatar(
+                        radius: 22,
+                        backgroundColor: theme.colorScheme.primary,
+                        child: Text(
+                          info.name.isNotEmpty ? info.name.characters.first : '?',
+                          style: theme.textTheme.titleMedium?.copyWith(color: Colors.white),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(info.name, style: theme.textTheme.titleMedium),
+                            Text('המאמן שלי',
+                                style: theme.textTheme.labelSmall?.copyWith(
+                                  color: theme.colorScheme.onSurfaceVariant,
+                                )),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (info.specialty != null || info.yearsExperience != null) ...[
+                    const SizedBox(height: 12),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 4,
+                      children: [
+                        if (info.specialty != null)
+                          _Pill(text: info.specialty!, icon: Icons.fitness_center),
+                        if (info.yearsExperience != null)
+                          _Pill(
+                            text: '${info.yearsExperience} שנות ניסיון',
+                            icon: Icons.workspace_premium,
+                          ),
+                      ],
+                    ),
+                  ],
+                  if (info.bio != null && info.bio!.isNotEmpty) ...[
+                    const SizedBox(height: 12),
+                    Text(info.bio!, style: theme.textTheme.bodyMedium),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _Pill extends StatelessWidget {
+  final String text;
+  final IconData icon;
+  const _Pill({required this.text, required this.icon});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: cs.primaryContainer,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 14, color: cs.onPrimaryContainer),
+          const SizedBox(width: 6),
+          Text(text,
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                color: cs.onPrimaryContainer,
+                fontWeight: FontWeight.w600,
+              )),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/coach/coach_dashboard_repository.dart
+++ b/mobile/lib/features/coach/coach_dashboard_repository.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../utils/authed_http_client.dart';
+
+class CoachDashboardView {
+  final int pendingApprovals;
+  final int pendingChangeRequests;
+  final int noShowsThisWeek;
+  final int todayRosterCount;
+
+  const CoachDashboardView({
+    required this.pendingApprovals,
+    required this.pendingChangeRequests,
+    required this.noShowsThisWeek,
+    required this.todayRosterCount,
+  });
+
+  factory CoachDashboardView.fromJson(Map<String, dynamic> json) =>
+      CoachDashboardView(
+        pendingApprovals: json['pendingApprovals'] as int? ?? 0,
+        pendingChangeRequests: json['pendingChangeRequests'] as int? ?? 0,
+        noShowsThisWeek: json['noShowsThisWeek'] as int? ?? 0,
+        todayRosterCount: (json['todayRoster'] as List?)?.length ?? 0,
+      );
+}
+
+abstract class CoachDashboardRepository {
+  Future<CoachDashboardView> fetch();
+}
+
+class HttpCoachDashboardRepository implements CoachDashboardRepository {
+  final AuthedHttpClient _http;
+  HttpCoachDashboardRepository(this._http);
+
+  @override
+  Future<CoachDashboardView> fetch() async {
+    final json = await _http.get<Map<String, dynamic>>('/api/admin/dashboard');
+    return CoachDashboardView.fromJson(json);
+  }
+}
+
+final coachDashboardRepositoryProvider =
+    Provider<CoachDashboardRepository>((ref) {
+  return HttpCoachDashboardRepository(ref.watch(authedHttpProvider));
+});
+
+final coachDashboardProvider = FutureProvider<CoachDashboardView>((ref) {
+  return ref.watch(coachDashboardRepositoryProvider).fetch();
+});

--- a/mobile/lib/features/coach/coach_info.dart
+++ b/mobile/lib/features/coach/coach_info.dart
@@ -1,13 +1,48 @@
 class CoachInfo {
   final String name;
   final String? contactPhone;
+  final String? bio;
+  final String? specialty;
+  final int? yearsExperience;
 
-  const CoachInfo({required this.name, required this.contactPhone});
+  const CoachInfo({
+    required this.name,
+    required this.contactPhone,
+    this.bio,
+    this.specialty,
+    this.yearsExperience,
+  });
 
   bool get hasContact => contactPhone != null && contactPhone!.isNotEmpty;
 
   factory CoachInfo.fromJson(Map<String, dynamic> json) => CoachInfo(
         name: json['name'] as String,
         contactPhone: json['contactPhone'] as String?,
+        bio: json['bio'] as String?,
+        specialty: json['specialty'] as String?,
+        yearsExperience: (json['yearsExperience'] as num?)?.toInt(),
       );
+}
+
+class CoachInfoPatch {
+  final String? contactPhone;
+  final String? bio;
+  final String? specialty;
+  final int? yearsExperience;
+
+  const CoachInfoPatch({
+    this.contactPhone,
+    this.bio,
+    this.specialty,
+    this.yearsExperience,
+  });
+
+  Map<String, dynamic> toJson() {
+    final m = <String, dynamic>{};
+    if (contactPhone != null) m['contactPhone'] = contactPhone;
+    if (bio != null) m['bio'] = bio;
+    if (specialty != null) m['specialty'] = specialty;
+    if (yearsExperience != null) m['yearsExperience'] = yearsExperience;
+    return m;
+  }
 }

--- a/mobile/lib/features/coach/coach_info_repository.dart
+++ b/mobile/lib/features/coach/coach_info_repository.dart
@@ -7,6 +7,7 @@ import 'coach_info.dart';
 abstract class CoachInfoRepository {
   Future<CoachInfo?> fetch();
   Future<void> updateContactPhone(String e164);
+  Future<void> update(CoachInfoPatch patch);
 }
 
 class HttpCoachInfoRepository implements CoachInfoRepository {
@@ -17,6 +18,11 @@ class HttpCoachInfoRepository implements CoachInfoRepository {
   @override
   Future<void> updateContactPhone(String e164) async {
     await _http.patch<void>('/api/coach-settings', data: {'contactPhone': e164});
+  }
+
+  @override
+  Future<void> update(CoachInfoPatch patch) async {
+    await _http.patch<void>('/api/coach-settings', data: patch.toJson());
   }
 
   @override

--- a/mobile/lib/features/coach/coach_settings_screen.dart
+++ b/mobile/lib/features/coach/coach_settings_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'coach_info.dart';
 import 'coach_info_repository.dart';
 
 class CoachSettingsScreen extends ConsumerStatefulWidget {
@@ -11,27 +12,70 @@ class CoachSettingsScreen extends ConsumerStatefulWidget {
 }
 
 class _CoachSettingsScreenState extends ConsumerState<CoachSettingsScreen> {
-  final _controller = TextEditingController();
+  final _phone = TextEditingController();
+  final _bio = TextEditingController();
+  final _specialty = TextEditingController();
+  final _years = TextEditingController();
+
   bool _initialised = false;
   bool _saving = false;
   String? _error;
+  String? _phoneError;
+  String? _yearsError;
 
   @override
   void dispose() {
-    _controller.dispose();
+    _phone.dispose();
+    _bio.dispose();
+    _specialty.dispose();
+    _years.dispose();
     super.dispose();
   }
 
+  CoachInfoPatch? _buildPatch() {
+    setState(() {
+      _phoneError = null;
+      _yearsError = null;
+    });
+
+    String? phone;
+    if (_phone.text.trim().isNotEmpty) {
+      phone = _phone.text.trim();
+      if (!RegExp(r'^\+\d{8,15}$').hasMatch(phone)) {
+        setState(() => _phoneError = 'טלפון לא תקין (+972...)');
+        return null;
+      }
+    }
+
+    int? years;
+    if (_years.text.trim().isNotEmpty) {
+      years = int.tryParse(_years.text.trim());
+      if (years == null || years < 0 || years > 80) {
+        setState(() => _yearsError = 'מספר לא תקין (0-80)');
+        return null;
+      }
+    }
+
+    return CoachInfoPatch(
+      contactPhone: phone,
+      bio: _bio.text.trim().isEmpty ? null : _bio.text.trim(),
+      specialty: _specialty.text.trim().isEmpty ? null : _specialty.text.trim(),
+      yearsExperience: years,
+    );
+  }
+
   Future<void> _save() async {
+    final patch = _buildPatch();
+    if (patch == null) return;
     setState(() {
       _saving = true;
       _error = null;
     });
     try {
-      await ref.read(coachInfoRepositoryProvider).updateContactPhone(_controller.text.trim());
+      await ref.read(coachInfoRepositoryProvider).update(patch);
+      ref.invalidate(coachInfoProvider);
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('נשמר')));
-      ref.invalidate(coachInfoProvider);
     } catch (e) {
       if (!mounted) return;
       setState(() => _error = e.toString());
@@ -50,37 +94,83 @@ class _CoachSettingsScreenState extends ConsumerState<CoachSettingsScreen> {
         error: (err, _) => Center(child: Text('שגיאה: $err')),
         data: (info) {
           if (!_initialised) {
-            _controller.text = info?.contactPhone ?? '';
+            _phone.text = info?.contactPhone ?? '';
+            _bio.text = info?.bio ?? '';
+            _specialty.text = info?.specialty ?? '';
+            _years.text = info?.yearsExperience?.toString() ?? '';
             _initialised = true;
           }
-          return Padding(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                TextField(
-                  key: const Key('contact-phone-field'),
-                  controller: _controller,
-                  keyboardType: TextInputType.phone,
-                  decoration: const InputDecoration(
-                    labelText: 'טלפון ליצירת קשר (E.164, למשל +972501234567)',
-                  ),
+          return ListView(
+            padding: const EdgeInsets.all(20),
+            children: [
+              _section('יצירת קשר'),
+              TextField(
+                key: const Key('contact-phone-field'),
+                controller: _phone,
+                keyboardType: TextInputType.phone,
+                decoration: InputDecoration(
+                  labelText: 'טלפון (E.164, למשל +972501234567)',
+                  errorText: _phoneError,
                 ),
-                const SizedBox(height: 24),
-                FilledButton(
-                  key: const Key('contact-phone-save'),
-                  onPressed: _saving ? null : _save,
-                  child: Text(_saving ? 'שומר...' : 'שמור'),
+              ),
+              const SizedBox(height: 24),
+              _section('הצגה למתאמנים'),
+              TextField(
+                key: const Key('coach-specialty-field'),
+                controller: _specialty,
+                decoration: const InputDecoration(
+                  labelText: 'התמחות (למשל: כוח, קרדיו, שיקום)',
                 ),
-                if (_error != null) ...[
-                  const SizedBox(height: 16),
-                  Text(_error!, style: TextStyle(color: Theme.of(context).colorScheme.error)),
-                ],
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('coach-years-field'),
+                controller: _years,
+                keyboardType: TextInputType.number,
+                decoration: InputDecoration(
+                  labelText: 'שנות ניסיון',
+                  errorText: _yearsError,
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('coach-bio-field'),
+                controller: _bio,
+                minLines: 3,
+                maxLines: 7,
+                decoration: const InputDecoration(
+                  labelText: 'תיאור קצר על עצמך',
+                ),
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                key: const Key('contact-phone-save'),
+                onPressed: _saving ? null : _save,
+                child: Text(_saving ? 'שומר...' : 'שמירה'),
+              ),
+              if (_error != null) ...[
+                const SizedBox(height: 16),
+                Text(
+                  _error!,
+                  key: const Key('coach-settings-error'),
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
               ],
-            ),
+            ],
           );
         },
       ),
     );
   }
+
+  Widget _section(String text) => Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: Text(
+          text,
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                color: Theme.of(context).colorScheme.primary,
+                fontWeight: FontWeight.bold,
+              ),
+        ),
+      );
 }

--- a/mobile/lib/features/coach/coach_trainee_detail_screen.dart
+++ b/mobile/lib/features/coach/coach_trainee_detail_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../design/spacing.dart';
+import '../../design/widgets.dart';
+import '../../theme.dart';
 import 'notes_sheet.dart';
 import 'trainee_detail_repository.dart';
 
@@ -25,14 +28,14 @@ class CoachTraineeDetailScreen extends ConsumerWidget {
           child: Text('שגיאה: $err', key: const Key('trainee-detail-error')),
         ),
         data: (v) => ListView(
-          padding: const EdgeInsets.all(20),
+          padding: const EdgeInsets.all(AppSpacing.lg),
           children: [
             _HeaderCard(view: v),
-            const SizedBox(height: 16),
+            const SizedBox(height: AppSpacing.lg),
             _BioCard(bio: v.bio),
-            const SizedBox(height: 16),
+            const SizedBox(height: AppSpacing.lg),
             _SessionsCard(sessions: v.sessions),
-            const SizedBox(height: 20),
+            const SizedBox(height: AppSpacing.lg),
             FilledButton.tonalIcon(
               key: const Key('open-notes-button'),
               icon: const Icon(Icons.sticky_note_2_outlined),
@@ -57,41 +60,78 @@ class _HeaderCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Card(
-      elevation: 0,
-      color: theme.colorScheme.primaryContainer.withValues(alpha: 0.4),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Row(
-          children: [
-            CircleAvatar(
-              radius: 28,
-              backgroundColor: theme.colorScheme.primary,
-              child: Text(
-                view.name.isNotEmpty ? view.name.characters.first : '?',
-                style: theme.textTheme.headlineSmall?.copyWith(color: Colors.white),
-              ),
+    return Row(
+      children: [
+        Container(
+          width: 56,
+          height: 56,
+          decoration: BoxDecoration(
+            gradient: const LinearGradient(
+              colors: [BrandColors.teal, BrandColors.tealDark],
+              begin: Alignment.topRight,
+              end: Alignment.bottomLeft,
             ),
-            const SizedBox(width: 16),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+            borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
+          ),
+          alignment: Alignment.center,
+          child: Text(
+            view.name.isNotEmpty ? view.name.characters.first : '?',
+            style: theme.textTheme.headlineSmall?.copyWith(
+              color: Colors.white,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.md),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(view.name, style: theme.textTheme.titleLarge),
+              const SizedBox(height: 2),
+              Row(
                 children: [
-                  Text(view.name, style: theme.textTheme.titleLarge),
-                  const SizedBox(height: 4),
+                  _StatusDot(
+                    color: view.isActive ? BrandColors.success : BrandColors.inkMuted,
+                  ),
+                  const SizedBox(width: AppSpacing.xs),
                   Text(
                     view.isActive ? 'פעיל' : 'מושבת',
                     key: const Key('trainee-active-label'),
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: view.isActive ? BrandColors.success : BrandColors.inkMuted,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.sm),
+                  Text(
+                    '·',
+                    style: theme.textTheme.bodySmall?.copyWith(color: BrandColors.inkMuted),
+                  ),
+                  const SizedBox(width: AppSpacing.sm),
+                  Text(
+                    '${view.weekBookingsCount} אימונים השבוע',
                     style: theme.textTheme.bodySmall,
                   ),
-                  Text('${view.weekBookingsCount} אימונים השבוע',
-                      style: theme.textTheme.bodySmall),
                 ],
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-      ),
+      ],
+    );
+  }
+}
+
+class _StatusDot extends StatelessWidget {
+  final Color color;
+  const _StatusDot({required this.color});
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
     );
   }
 }
@@ -102,58 +142,65 @@ class _BioCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
+    return Container(
       key: const Key('bio-card'),
-      elevation: 0,
-      shape: RoundedRectangleBorder(
-        side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
-        borderRadius: BorderRadius.circular(16),
+      decoration: BoxDecoration(
+        color: BrandColors.surface,
+        borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
+        border: Border.all(color: BrandColors.line),
       ),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('פרופיל אישי', style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 12),
-            _row(Icons.phone, 'טלפון', bio.phone ?? 'חסר'),
-            _row(Icons.cake_outlined, 'גיל', _ageText(bio.dateOfBirth)),
-            _row(Icons.height, 'גובה',
-                bio.heightCm == null ? 'חסר' : '${bio.heightCm} ס״מ'),
-            _row(Icons.monitor_weight_outlined, 'משקל',
-                bio.weightKg == null ? 'חסר' : '${bio.weightKg} ק״ג'),
-            _row(Icons.flag_outlined, 'מטרות', bio.goals ?? 'חסר'),
-            _row(Icons.medical_information_outlined, 'מידע רפואי',
-                bio.medical ?? 'חסר'),
-            if (bio.introText != null && bio.introText!.isNotEmpty) ...[
-              const SizedBox(height: 8),
-              Text('הצגה עצמית',
-                  style: Theme.of(context).textTheme.titleSmall),
-              const SizedBox(height: 4),
-              Text(bio.introText!),
-            ],
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SectionHeader('פרופיל אישי'),
+          DataGrid(children: [
+            InfoRow(icon: Icons.cake_outlined, label: 'גיל', value: _ageText(bio.dateOfBirth)),
+            InfoRow(icon: Icons.phone_outlined, label: 'טלפון', value: bio.phone),
+            InfoRow(
+              icon: Icons.height,
+              label: 'גובה',
+              value: bio.heightCm == null ? null : '${bio.heightCm} ס״מ',
+            ),
+            InfoRow(
+              icon: Icons.monitor_weight_outlined,
+              label: 'משקל',
+              value: bio.weightKg == null ? null : '${bio.weightKg} ק״ג',
+            ),
+          ]),
+          const SizedBox(height: AppSpacing.md),
+          const SectionHeader('מטרות ומגבלות'),
+          InfoRow(icon: Icons.flag_outlined, label: 'מטרות', value: bio.goals),
+          InfoRow(
+            icon: Icons.medical_information_outlined,
+            label: 'מידע רפואי',
+            value: bio.medical,
+          ),
+          if (bio.introText != null && bio.introText!.isNotEmpty) ...[
+            const SizedBox(height: AppSpacing.md),
+            const SectionHeader('הצגה עצמית'),
+            Container(
+              padding: const EdgeInsets.all(AppSpacing.sm),
+              decoration: BoxDecoration(
+                color: BrandColors.bg,
+                borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+                border: Border(
+                  right: BorderSide(color: BrandColors.teal, width: 2),
+                ),
+              ),
+              child: Text(
+                bio.introText!,
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+            ),
           ],
-        ),
+        ],
       ),
     );
   }
 
-  Widget _row(IconData icon, String label, String value) => Padding(
-        padding: const EdgeInsets.symmetric(vertical: 4),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Icon(icon, size: 18),
-            const SizedBox(width: 10),
-            Text('$label:'),
-            const SizedBox(width: 6),
-            Expanded(child: Text(value)),
-          ],
-        ),
-      );
-
-  String _ageText(String? dob) {
-    if (dob == null) return 'חסר';
+  String? _ageText(String? dob) {
+    if (dob == null) return null;
     try {
       final d = DateTime.parse(dob);
       final now = DateTime.now();
@@ -161,7 +208,7 @@ class _BioCard extends StatelessWidget {
       if (now.month < d.month || (now.month == d.month && now.day < d.day)) age -= 1;
       return '$age';
     } catch (_) {
-      return 'חסר';
+      return null;
     }
   }
 }
@@ -172,36 +219,69 @@ class _SessionsCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      elevation: 0,
-      shape: RoundedRectangleBorder(
-        side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
-        borderRadius: BorderRadius.circular(16),
+    return Container(
+      decoration: BoxDecoration(
+        color: BrandColors.surface,
+        borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
+        border: Border.all(color: BrandColors.line),
       ),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('אימונים אחרונים',
-                style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            if (sessions.isEmpty)
-              const Text('אין אימונים קודמים', key: Key('sessions-empty')),
-            for (final s in sessions.take(5))
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 4),
-                child: Row(
-                  children: [
-                    const Icon(Icons.event, size: 18),
-                    const SizedBox(width: 10),
-                    Text('${s.date}  ${s.startTime}'),
-                  ],
-                ),
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SectionHeader('אימונים אחרונים'),
+          if (sessions.isEmpty)
+            Text(
+              'אין אימונים קודמים',
+              key: const Key('sessions-empty'),
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: BrandColors.inkMuted,
+                fontStyle: FontStyle.italic,
               ),
-          ],
-        ),
+            ),
+          for (final s in sessions.take(5)) _SessionRow(session: s),
+        ],
       ),
     );
   }
 }
+
+class _SessionRow extends StatelessWidget {
+  final TraineeSession session;
+  const _SessionRow({required this.session});
+
+  @override
+  Widget build(BuildContext context) {
+    final day = int.tryParse(session.date.substring(8, 10)) ?? 0;
+    final mon = int.tryParse(session.date.substring(5, 7)) ?? 0;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      child: Row(
+        children: [
+          Container(
+            width: 4,
+            height: 18,
+            decoration: BoxDecoration(
+              color: BrandColors.teal,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Text(
+            session.startTime,
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+              color: BrandColors.ink,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Text(
+            '$day.$mon',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/mobile/lib/features/coach/coach_trainee_detail_screen.dart
+++ b/mobile/lib/features/coach/coach_trainee_detail_screen.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'notes_sheet.dart';
+import 'trainee_detail_repository.dart';
+
+class CoachTraineeDetailScreen extends ConsumerWidget {
+  final String traineeId;
+  const CoachTraineeDetailScreen({super.key, required this.traineeId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(traineeDetailProvider(traineeId));
+    return Scaffold(
+      appBar: AppBar(
+        title: async.when(
+          loading: () => const Text('טוען...'),
+          error: (_, _) => const Text('שגיאה'),
+          data: (v) => Text(v.name),
+        ),
+      ),
+      body: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, _) => Center(
+          child: Text('שגיאה: $err', key: const Key('trainee-detail-error')),
+        ),
+        data: (v) => ListView(
+          padding: const EdgeInsets.all(20),
+          children: [
+            _HeaderCard(view: v),
+            const SizedBox(height: 16),
+            _BioCard(bio: v.bio),
+            const SizedBox(height: 16),
+            _SessionsCard(sessions: v.sessions),
+            const SizedBox(height: 20),
+            FilledButton.tonalIcon(
+              key: const Key('open-notes-button'),
+              icon: const Icon(Icons.sticky_note_2_outlined),
+              label: const Text('הערות על המתאמן'),
+              onPressed: () => showModalBottomSheet<void>(
+                context: context,
+                isScrollControlled: true,
+                builder: (_) => NotesSheet(traineeId: v.id, traineeName: v.name),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HeaderCard extends StatelessWidget {
+  final TraineeDetailView view;
+  const _HeaderCard({required this.view});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.primaryContainer.withValues(alpha: 0.4),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            CircleAvatar(
+              radius: 28,
+              backgroundColor: theme.colorScheme.primary,
+              child: Text(
+                view.name.isNotEmpty ? view.name.characters.first : '?',
+                style: theme.textTheme.headlineSmall?.copyWith(color: Colors.white),
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(view.name, style: theme.textTheme.titleLarge),
+                  const SizedBox(height: 4),
+                  Text(
+                    view.isActive ? 'פעיל' : 'מושבת',
+                    key: const Key('trainee-active-label'),
+                    style: theme.textTheme.bodySmall,
+                  ),
+                  Text('${view.weekBookingsCount} אימונים השבוע',
+                      style: theme.textTheme.bodySmall),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BioCard extends StatelessWidget {
+  final TraineeBio bio;
+  const _BioCard({required this.bio});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: const Key('bio-card'),
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('פרופיל אישי', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 12),
+            _row(Icons.phone, 'טלפון', bio.phone ?? 'חסר'),
+            _row(Icons.cake_outlined, 'גיל', _ageText(bio.dateOfBirth)),
+            _row(Icons.height, 'גובה',
+                bio.heightCm == null ? 'חסר' : '${bio.heightCm} ס״מ'),
+            _row(Icons.monitor_weight_outlined, 'משקל',
+                bio.weightKg == null ? 'חסר' : '${bio.weightKg} ק״ג'),
+            _row(Icons.flag_outlined, 'מטרות', bio.goals ?? 'חסר'),
+            _row(Icons.medical_information_outlined, 'מידע רפואי',
+                bio.medical ?? 'חסר'),
+            if (bio.introText != null && bio.introText!.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text('הצגה עצמית',
+                  style: Theme.of(context).textTheme.titleSmall),
+              const SizedBox(height: 4),
+              Text(bio.introText!),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _row(IconData icon, String label, String value) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, size: 18),
+            const SizedBox(width: 10),
+            Text('$label:'),
+            const SizedBox(width: 6),
+            Expanded(child: Text(value)),
+          ],
+        ),
+      );
+
+  String _ageText(String? dob) {
+    if (dob == null) return 'חסר';
+    try {
+      final d = DateTime.parse(dob);
+      final now = DateTime.now();
+      int age = now.year - d.year;
+      if (now.month < d.month || (now.month == d.month && now.day < d.day)) age -= 1;
+      return '$age';
+    } catch (_) {
+      return 'חסר';
+    }
+  }
+}
+
+class _SessionsCard extends StatelessWidget {
+  final List<TraineeSession> sessions;
+  const _SessionsCard({required this.sessions});
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('אימונים אחרונים',
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            if (sessions.isEmpty)
+              const Text('אין אימונים קודמים', key: Key('sessions-empty')),
+            for (final s in sessions.take(5))
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: Row(
+                  children: [
+                    const Icon(Icons.event, size: 18),
+                    const SizedBox(width: 10),
+                    Text('${s.date}  ${s.startTime}'),
+                  ],
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/coach/coach_trainees_screen.dart
+++ b/mobile/lib/features/coach/coach_trainees_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'admin_repository.dart';
+import 'coach_trainee_detail_screen.dart';
 import 'notes_sheet.dart';
 
 String statusLabel(String status) {
@@ -107,10 +108,16 @@ class _TraineeRow extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Padding(
+    return InkWell(
       key: Key('trainee-row-${trainee.id}'),
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Row(
+      onTap: () => Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (_) => CoachTraineeDetailScreen(traineeId: trainee.id),
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Row(
         children: [
           Expanded(
             child: Column(
@@ -169,6 +176,7 @@ class _TraineeRow extends ConsumerWidget {
               onPressed: () => _confirmDeactivate(context, ref),
             ),
         ],
+        ),
       ),
     );
   }

--- a/mobile/lib/features/coach/coach_week_screen.dart
+++ b/mobile/lib/features/coach/coach_week_screen.dart
@@ -8,6 +8,7 @@ import '../slots/slot.dart';
 import '../slots/slot_repository.dart';
 import 'admin_repository.dart';
 import 'approvals_repository.dart';
+import 'change_requests_screen.dart';
 import 'coach_dashboard_repository.dart';
 import 'coach_trainees_screen.dart';
 import 'pending_approvals_screen.dart';
@@ -224,6 +225,9 @@ class _CoachDashboard extends ConsumerWidget {
                 value: '$changeRequestsCount',
                 label: 'בקשות שינוי',
                 highlight: changeRequestsCount > 0,
+                onTap: () => Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const ChangeRequestsScreen()),
+                ),
               ),
               const SizedBox(width: 10),
               _DashStat(
@@ -251,34 +255,48 @@ class _DashStat extends StatelessWidget {
   final String value;
   final String label;
   final bool highlight;
-  const _DashStat({super.key, required this.value, required this.label, this.highlight = false});
+  final VoidCallback? onTap;
+  const _DashStat({
+    super.key,
+    required this.value,
+    required this.label,
+    this.highlight = false,
+    this.onTap,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-        decoration: BoxDecoration(
-          color: highlight
-              ? BrandColors.orange.withValues(alpha: 0.85)
-              : Colors.white.withValues(alpha: 0.18),
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(value,
-                style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w800,
-                    )),
-            Text(label,
-                style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                      color: Colors.white.withValues(alpha: 0.9),
-                    )),
-          ],
-        ),
+    final inner = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+      decoration: BoxDecoration(
+        color: highlight
+            ? BrandColors.orange.withValues(alpha: 0.85)
+            : Colors.white.withValues(alpha: 0.18),
+        borderRadius: BorderRadius.circular(12),
       ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(value,
+              style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w800,
+                  )),
+          Text(label,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: Colors.white.withValues(alpha: 0.9),
+                  )),
+        ],
+      ),
+    );
+    return Expanded(
+      child: onTap == null
+          ? inner
+          : InkWell(
+              onTap: onTap,
+              borderRadius: BorderRadius.circular(12),
+              child: inner,
+            ),
     );
   }
 }

--- a/mobile/lib/features/coach/coach_week_screen.dart
+++ b/mobile/lib/features/coach/coach_week_screen.dart
@@ -8,6 +8,7 @@ import '../slots/slot.dart';
 import '../slots/slot_repository.dart';
 import 'admin_repository.dart';
 import 'approvals_repository.dart';
+import 'coach_dashboard_repository.dart';
 import 'coach_trainees_screen.dart';
 import 'pending_approvals_screen.dart';
 
@@ -176,8 +177,11 @@ class _CoachDashboard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final bookings = ref.watch(adminBookingsForDateProvider(selectedDate)).valueOrNull ?? [];
     final trainees = ref.watch(traineeRecordsProvider).valueOrNull ?? [];
+    final dashboard = ref.watch(coachDashboardProvider).valueOrNull;
     final pendingCount = trainees.where((t) => t.status == 'pending').length;
     final activeCount = trainees.where((t) => t.status == 'active').length;
+    final changeRequestsCount = dashboard?.pendingChangeRequests ?? 0;
+    final noShowsThisWeek = dashboard?.noShowsThisWeek ?? 0;
 
     return Container(
       width: double.infinity,
@@ -207,9 +211,28 @@ class _CoachDashboard extends ConsumerWidget {
               const SizedBox(width: 10),
               _DashStat(
                 value: '$pendingCount',
-                label: 'אישורים בהמתנה',
+                label: 'אישורים',
                 highlight: pendingCount > 0,
               ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              _DashStat(
+                key: const Key('change-requests-stat'),
+                value: '$changeRequestsCount',
+                label: 'בקשות שינוי',
+                highlight: changeRequestsCount > 0,
+              ),
+              const SizedBox(width: 10),
+              _DashStat(
+                key: const Key('no-shows-stat'),
+                value: '$noShowsThisWeek',
+                label: 'אי-הגעה השבוע',
+              ),
+              const SizedBox(width: 10),
+              const _DashSpacer(),
             ],
           ),
         ],
@@ -218,11 +241,17 @@ class _CoachDashboard extends ConsumerWidget {
   }
 }
 
+class _DashSpacer extends StatelessWidget {
+  const _DashSpacer();
+  @override
+  Widget build(BuildContext context) => const Expanded(child: SizedBox.shrink());
+}
+
 class _DashStat extends StatelessWidget {
   final String value;
   final String label;
   final bool highlight;
-  const _DashStat({required this.value, required this.label, this.highlight = false});
+  const _DashStat({super.key, required this.value, required this.label, this.highlight = false});
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/lib/features/coach/trainee_detail_repository.dart
+++ b/mobile/lib/features/coach/trainee_detail_repository.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../utils/authed_http_client.dart';
+
+class TraineeDetailView {
+  final String id;
+  final String name;
+  final bool isActive;
+  final TraineeBio bio;
+  final List<TraineeSession> sessions;
+  final int weekBookingsCount;
+
+  const TraineeDetailView({
+    required this.id,
+    required this.name,
+    required this.isActive,
+    required this.bio,
+    required this.sessions,
+    required this.weekBookingsCount,
+  });
+
+  factory TraineeDetailView.fromJson(Map<String, dynamic> json) {
+    final t = json['trainee'] as Map<String, dynamic>;
+    final p = (json['profile'] as Map<String, dynamic>?) ?? const {};
+    final sessions =
+        ((json['sessions'] as List?) ?? const []).cast<Map<String, dynamic>>();
+    return TraineeDetailView(
+      id: t['id'] as String,
+      name: t['name'] as String,
+      isActive: (t['isActive'] as bool?) ?? true,
+      bio: TraineeBio.fromJson(p),
+      sessions: sessions.map(TraineeSession.fromJson).toList(),
+      weekBookingsCount: (json['weekBookingsCount'] as int?) ?? 0,
+    );
+  }
+}
+
+class TraineeBio {
+  final String? phone;
+  final String? introText;
+  final String? dateOfBirth;
+  final int? heightCm;
+  final int? weightKg;
+  final String? goals;
+  final String? medical;
+
+  const TraineeBio({
+    this.phone,
+    this.introText,
+    this.dateOfBirth,
+    this.heightCm,
+    this.weightKg,
+    this.goals,
+    this.medical,
+  });
+
+  factory TraineeBio.fromJson(Map<String, dynamic> json) => TraineeBio(
+        phone: json['phone'] as String?,
+        introText: json['introText'] as String?,
+        dateOfBirth: json['dateOfBirth'] as String?,
+        heightCm: (json['heightCm'] as num?)?.toInt(),
+        weightKg: (json['weightKg'] as num?)?.toInt(),
+        goals: json['goals'] as String?,
+        medical: json['medical'] as String?,
+      );
+}
+
+class TraineeSession {
+  final String bookingId;
+  final String date;
+  final String startTime;
+  const TraineeSession({
+    required this.bookingId,
+    required this.date,
+    required this.startTime,
+  });
+
+  factory TraineeSession.fromJson(Map<String, dynamic> json) => TraineeSession(
+        bookingId: json['bookingId'] as String,
+        date: json['date'] as String,
+        startTime: json['startTime'] as String,
+      );
+}
+
+abstract class TraineeDetailRepository {
+  Future<TraineeDetailView> fetch(String traineeId);
+}
+
+class HttpTraineeDetailRepository implements TraineeDetailRepository {
+  final AuthedHttpClient _http;
+  HttpTraineeDetailRepository(this._http);
+
+  @override
+  Future<TraineeDetailView> fetch(String traineeId) async {
+    final json =
+        await _http.get<Map<String, dynamic>>('/api/admin/trainees/$traineeId');
+    return TraineeDetailView.fromJson(json);
+  }
+}
+
+final traineeDetailRepositoryProvider =
+    Provider<TraineeDetailRepository>((ref) {
+  return HttpTraineeDetailRepository(ref.watch(authedHttpProvider));
+});
+
+final traineeDetailProvider =
+    FutureProvider.family<TraineeDetailView, String>((ref, traineeId) {
+  return ref.watch(traineeDetailRepositoryProvider).fetch(traineeId);
+});

--- a/mobile/lib/features/dashboard/dashboard_repository.dart
+++ b/mobile/lib/features/dashboard/dashboard_repository.dart
@@ -7,30 +7,39 @@ class TraineeDashboard {
   final int pastConfirmed;
   final int noShows;
   final double attendanceRate;
+  final int currentStreak;
   final String? nextSessionAt; // ISO
   final VisibleNote? recentVisibleNote;
   final int remainingEdits;
+  final int memberSinceDays;
 
   const TraineeDashboard({
     required this.sessionsThisMonth,
     required this.pastConfirmed,
     required this.noShows,
     required this.attendanceRate,
+    required this.currentStreak,
     required this.nextSessionAt,
     required this.recentVisibleNote,
     required this.remainingEdits,
+    required this.memberSinceDays,
   });
+
+  /// Whole months since registration (floor; 30-day approximation).
+  int get memberSinceMonths => memberSinceDays ~/ 30;
 
   factory TraineeDashboard.fromJson(Map<String, dynamic> json) => TraineeDashboard(
         sessionsThisMonth: json['sessionsThisMonth'] as int? ?? 0,
         pastConfirmed: json['pastConfirmed'] as int? ?? 0,
         noShows: json['noShows'] as int? ?? 0,
         attendanceRate: (json['attendanceRate'] as num?)?.toDouble() ?? 1.0,
+        currentStreak: json['currentStreak'] as int? ?? 0,
         nextSessionAt: json['nextSessionAt'] as String?,
         recentVisibleNote: json['recentVisibleNote'] == null
             ? null
             : VisibleNote.fromJson(json['recentVisibleNote'] as Map<String, dynamic>),
         remainingEdits: json['remainingEdits'] as int? ?? 3,
+        memberSinceDays: json['memberSinceDays'] as int? ?? 0,
       );
 }
 

--- a/mobile/lib/features/history/history_repository.dart
+++ b/mobile/lib/features/history/history_repository.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../utils/authed_http_client.dart';
+
+class HistoryEntry {
+  final String bookingId;
+  final String slotId;
+  final String date; // YYYY-MM-DD
+  final String startTime; // HH:mm
+  final String status; // confirmed | cancelled | no_show
+  final String startsAt; // ISO
+  final bool isPast;
+
+  const HistoryEntry({
+    required this.bookingId,
+    required this.slotId,
+    required this.date,
+    required this.startTime,
+    required this.status,
+    required this.startsAt,
+    required this.isPast,
+  });
+
+  factory HistoryEntry.fromJson(Map<String, dynamic> json) => HistoryEntry(
+        bookingId: json['bookingId'] as String,
+        slotId: json['slotId'] as String,
+        date: json['date'] as String,
+        startTime: json['startTime'] as String,
+        status: json['status'] as String,
+        startsAt: json['startsAt'] as String,
+        isPast: json['isPast'] as bool? ?? false,
+      );
+}
+
+abstract class HistoryRepository {
+  Future<List<HistoryEntry>> fetch();
+}
+
+class HttpHistoryRepository implements HistoryRepository {
+  final AuthedHttpClient _http;
+  HttpHistoryRepository(this._http);
+
+  @override
+  Future<List<HistoryEntry>> fetch() async {
+    final json = await _http.get<Map<String, dynamic>>('/api/me/history');
+    final list = (json['history'] as List).cast<Map<String, dynamic>>();
+    return list.map(HistoryEntry.fromJson).toList();
+  }
+}
+
+final historyRepositoryProvider = Provider<HistoryRepository>(
+  (ref) => HttpHistoryRepository(ref.watch(authedHttpProvider)),
+);
+
+final historyProvider = FutureProvider<List<HistoryEntry>>(
+  (ref) => ref.watch(historyRepositoryProvider).fetch(),
+);

--- a/mobile/lib/features/history/history_screen.dart
+++ b/mobile/lib/features/history/history_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../design/spacing.dart';
+import '../../design/widgets.dart';
+import '../../theme.dart';
 import 'history_repository.dart';
 
 class HistoryScreen extends ConsumerWidget {
@@ -23,9 +26,9 @@ class HistoryScreen extends ConsumerWidget {
               child: Text('עדיין אין היסטוריית אימונים'),
             );
           }
-          // Group entries by year-month.
           final months = _groupByMonth(entries);
           return ListView.builder(
+            padding: const EdgeInsets.only(bottom: AppSpacing.lg),
             itemCount: months.length,
             itemBuilder: (_, i) {
               final m = months[i];
@@ -33,17 +36,15 @@ class HistoryScreen extends ConsumerWidget {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Padding(
-                    padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
-                    child: Text(
-                      _monthLabel(m.year, m.month),
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            color: Theme.of(context).colorScheme.primary,
-                            fontWeight: FontWeight.bold,
-                          ),
+                    padding: const EdgeInsets.fromLTRB(
+                      AppSpacing.lg,
+                      AppSpacing.lg,
+                      AppSpacing.lg,
+                      AppSpacing.xs,
                     ),
+                    child: SectionHeader(_monthLabel(m.year, m.month)),
                   ),
-                  for (final e in m.entries)
-                    _HistoryTile(entry: e),
+                  for (final e in m.entries) _HistoryTile(entry: e),
                 ],
               );
             },
@@ -63,8 +64,9 @@ class HistoryScreen extends ConsumerWidget {
       map[key]!.entries.add(e);
     }
     final result = map.values.toList();
-    result.sort((a, b) =>
-        b.year.compareTo(a.year) != 0 ? b.year.compareTo(a.year) : b.month.compareTo(a.month));
+    result.sort((a, b) => b.year.compareTo(a.year) != 0
+        ? b.year.compareTo(a.year)
+        : b.month.compareTo(a.month));
     return result;
   }
 
@@ -90,35 +92,37 @@ class _HistoryTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-    final (icon, color, label) = _decoration(cs, entry.status, entry.isPast);
+    final theme = Theme.of(context);
+    final (stripe, label) = _decoration(entry.status, entry.isPast);
     final day = int.parse(entry.date.substring(8, 10));
     final mon = int.parse(entry.date.substring(5, 7));
 
-    return ListTile(
+    return StatusStripeTile(
       key: Key('history-tile-${entry.bookingId}'),
-      leading: CircleAvatar(
-        backgroundColor: color.withValues(alpha: 0.15),
-        child: Icon(icon, color: color),
+      stripeColor: stripe,
+      title: Text(
+        '${entry.startTime}  ·  $day.$mon',
+        style: theme.textTheme.titleMedium,
       ),
-      title: Text('${entry.startTime} • $day.$mon'),
-      subtitle: Text(label),
-      dense: true,
+      subtitle: Text(
+        label,
+        style: theme.textTheme.bodySmall?.copyWith(color: stripe),
+      ),
     );
   }
 
-  (IconData, Color, String) _decoration(ColorScheme cs, String status, bool isPast) {
+  (Color, String) _decoration(String status, bool isPast) {
     switch (status) {
       case 'confirmed':
         return isPast
-            ? (Icons.check_circle, Colors.green.shade700, 'הושלם')
-            : (Icons.event, cs.primary, 'אישור');
+            ? (BrandColors.success, 'הושלם')
+            : (BrandColors.teal, 'מתוכנן');
       case 'cancelled':
-        return (Icons.cancel_outlined, cs.error, 'בוטל');
+        return (BrandColors.inkMuted, 'בוטל');
       case 'no_show':
-        return (Icons.report_gmailerrorred, Colors.orange.shade800, 'לא הגיע');
+        return (BrandColors.orange, 'לא הגיע');
       default:
-        return (Icons.help_outline, cs.outline, status);
+        return (BrandColors.inkMuted, status);
     }
   }
 }

--- a/mobile/lib/features/history/history_screen.dart
+++ b/mobile/lib/features/history/history_screen.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'history_repository.dart';
+
+class HistoryScreen extends ConsumerWidget {
+  const HistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(historyProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('היסטוריית אימונים')),
+      body: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, _) => Center(
+          child: Text('שגיאה: $err', key: const Key('history-error')),
+        ),
+        data: (entries) {
+          if (entries.isEmpty) {
+            return const Center(
+              key: Key('history-empty'),
+              child: Text('עדיין אין היסטוריית אימונים'),
+            );
+          }
+          // Group entries by year-month.
+          final months = _groupByMonth(entries);
+          return ListView.builder(
+            itemCount: months.length,
+            itemBuilder: (_, i) {
+              final m = months[i];
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
+                    child: Text(
+                      _monthLabel(m.year, m.month),
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            color: Theme.of(context).colorScheme.primary,
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                  ),
+                  for (final e in m.entries)
+                    _HistoryTile(entry: e),
+                ],
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  static List<_Month> _groupByMonth(List<HistoryEntry> entries) {
+    final map = <String, _Month>{};
+    for (final e in entries) {
+      final y = int.parse(e.date.substring(0, 4));
+      final m = int.parse(e.date.substring(5, 7));
+      final key = '$y-$m';
+      map.putIfAbsent(key, () => _Month(y, m, []));
+      map[key]!.entries.add(e);
+    }
+    final result = map.values.toList();
+    result.sort((a, b) =>
+        b.year.compareTo(a.year) != 0 ? b.year.compareTo(a.year) : b.month.compareTo(a.month));
+    return result;
+  }
+
+  static String _monthLabel(int year, int month) {
+    const names = [
+      '', 'ינואר', 'פברואר', 'מרץ', 'אפריל', 'מאי', 'יוני',
+      'יולי', 'אוגוסט', 'ספטמבר', 'אוקטובר', 'נובמבר', 'דצמבר',
+    ];
+    return '${names[month]} $year';
+  }
+}
+
+class _Month {
+  final int year;
+  final int month;
+  final List<HistoryEntry> entries;
+  _Month(this.year, this.month, this.entries);
+}
+
+class _HistoryTile extends StatelessWidget {
+  final HistoryEntry entry;
+  const _HistoryTile({required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final (icon, color, label) = _decoration(cs, entry.status, entry.isPast);
+    final day = int.parse(entry.date.substring(8, 10));
+    final mon = int.parse(entry.date.substring(5, 7));
+
+    return ListTile(
+      key: Key('history-tile-${entry.bookingId}'),
+      leading: CircleAvatar(
+        backgroundColor: color.withValues(alpha: 0.15),
+        child: Icon(icon, color: color),
+      ),
+      title: Text('${entry.startTime} • $day.$mon'),
+      subtitle: Text(label),
+      dense: true,
+    );
+  }
+
+  (IconData, Color, String) _decoration(ColorScheme cs, String status, bool isPast) {
+    switch (status) {
+      case 'confirmed':
+        return isPast
+            ? (Icons.check_circle, Colors.green.shade700, 'הושלם')
+            : (Icons.event, cs.primary, 'אישור');
+      case 'cancelled':
+        return (Icons.cancel_outlined, cs.error, 'בוטל');
+      case 'no_show':
+        return (Icons.report_gmailerrorred, Colors.orange.shade800, 'לא הגיע');
+      default:
+        return (Icons.help_outline, cs.outline, status);
+    }
+  }
+}

--- a/mobile/lib/features/profile/profile_screen.dart
+++ b/mobile/lib/features/profile/profile_screen.dart
@@ -6,7 +6,10 @@ import '../auth/auth_repository.dart';
 import '../auth/login_screen.dart';
 import '../coach/calendar_repository.dart';
 import '../coach/coach_settings_screen.dart';
+import 'profile.dart';
 import 'profile_repository.dart';
+import 'trainee_profile_editor_screen.dart';
+import 'trainee_profile_repository.dart';
 
 String roleLabel(String role) {
   switch (role) {
@@ -53,84 +56,215 @@ class ProfileScreen extends ConsumerWidget {
             textAlign: TextAlign.center,
           ),
         ),
-        data: (profile) => Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(profile.name,
-                  key: const Key('profile-name'),
-                  style: Theme.of(context).textTheme.headlineMedium),
-              const SizedBox(height: 8),
-              Text(roleLabel(profile.role),
-                  key: const Key('profile-role'),
-                  style: Theme.of(context).textTheme.titleMedium),
-              const SizedBox(height: 4),
-              Text(profile.email,
-                  style: Theme.of(context).textTheme.bodyMedium),
-              if (profile.role == 'coach') ...[
-                const SizedBox(height: 24),
-                FilledButton.tonalIcon(
-                  key: const Key('coach-settings-link'),
-                  icon: const Icon(Icons.settings),
-                  label: const Text('הגדרות מאמן'),
-                  onPressed: () => Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const CoachSettingsScreen()),
+        data: (profile) => ListView(
+          padding: const EdgeInsets.all(20),
+          children: [
+            _IdentityCard(profile: profile),
+            const SizedBox(height: 16),
+            if (profile.role == 'trainee') ...[
+              _TraineePreviewCard(),
+              const SizedBox(height: 16),
+              FilledButton.icon(
+                key: const Key('edit-profile-button'),
+                icon: const Icon(Icons.edit),
+                label: const Text('ערוך פרופיל'),
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const TraineeProfileEditorScreen(),
                   ),
                 ),
-                const SizedBox(height: 12),
-                Consumer(
-                  builder: (context, ref, _) {
-                    final status = ref.watch(calendarStatusProvider).valueOrNull;
-                    if (status == null) {
-                      return const SizedBox(
-                        height: 24,
-                        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
-                      );
-                    }
-                    if (status.mock) {
-                      return Container(
-                        key: const Key('calendar-mock'),
-                        padding: const EdgeInsets.all(12),
-                        decoration: BoxDecoration(
-                          color: Colors.amber.shade100,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: const Text(
-                          '🛠 יומן Google במצב סימולציה (פיתוח)',
-                          textAlign: TextAlign.center,
-                        ),
-                      );
-                    }
-                    if (status.connected) {
-                      return const Text(
-                        '✓ יומן Google מחובר',
-                        key: Key('calendar-connected'),
-                      );
-                    }
-                    return FilledButton.tonalIcon(
-                      key: const Key('connect-calendar-button'),
-                      icon: const Icon(Icons.calendar_today),
-                      label: const Text('חבר יומן Google'),
-                      onPressed: () async {
-                        try {
-                          final url = await ref.read(calendarRepositoryProvider).getAuthUrl();
-                          await ref.read(urlOpenerProvider).open(Uri.parse(url));
-                        } catch (e) {
-                          if (!context.mounted) return;
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text('שגיאה: $e')),
-                          );
-                        }
-                      },
-                    );
-                  },
+              ),
+            ],
+            if (profile.role == 'coach') ...[
+              FilledButton.tonalIcon(
+                key: const Key('coach-settings-link'),
+                icon: const Icon(Icons.settings),
+                label: const Text('הגדרות מאמן'),
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const CoachSettingsScreen()),
                 ),
-              ],
+              ),
+              const SizedBox(height: 12),
+              const _CoachCalendarStatus(),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IdentityCard extends StatelessWidget {
+  final Profile profile;
+  const _IdentityCard({required this.profile});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: [
+            CircleAvatar(
+              radius: 32,
+              backgroundColor: theme.colorScheme.primaryContainer,
+              child: Text(
+                profile.name.isNotEmpty ? profile.name.characters.first : '?',
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  color: theme.colorScheme.onPrimaryContainer,
+                ),
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(profile.name,
+                      key: const Key('profile-name'),
+                      style: theme.textTheme.headlineSmall),
+                  const SizedBox(height: 4),
+                  Text(roleLabel(profile.role),
+                      key: const Key('profile-role'),
+                      style: theme.textTheme.titleSmall?.copyWith(
+                        color: theme.colorScheme.primary,
+                      )),
+                  const SizedBox(height: 2),
+                  Text(profile.email,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      )),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TraineePreviewCard extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(traineeProfileProvider);
+    return Card(
+      key: const Key('trainee-preview-card'),
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: async.when(
+          loading: () => const SizedBox(
+            height: 100,
+            child: Center(child: CircularProgressIndicator()),
+          ),
+          error: (e, _) => Text('שגיאה: $e'),
+          data: (tp) => Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('פרטי המתאמן',
+                  style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 12),
+              _row(Icons.phone, 'טלפון', tp.phone ?? 'חסר'),
+              _row(Icons.cake_outlined, 'גיל', _ageText(tp.dateOfBirth)),
+              _row(Icons.height, 'גובה',
+                  tp.heightCm == null ? 'חסר' : '${tp.heightCm} ס״מ'),
+              _row(Icons.monitor_weight_outlined, 'משקל',
+                  tp.weightKg == null ? 'חסר' : '${tp.weightKg} ק״ג'),
+              _row(Icons.flag_outlined, 'מטרות', tp.goals ?? 'חסר'),
             ],
           ),
         ),
       ),
+    );
+  }
+
+  Widget _row(IconData icon, String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        children: [
+          Icon(icon, size: 20),
+          const SizedBox(width: 12),
+          Text('$label:'),
+          const SizedBox(width: 8),
+          Expanded(child: Text(value, textAlign: TextAlign.start)),
+        ],
+      ),
+    );
+  }
+
+  String _ageText(String? dob) {
+    if (dob == null) return 'חסר';
+    try {
+      final d = DateTime.parse(dob);
+      final now = DateTime.now();
+      int age = now.year - d.year;
+      if (now.month < d.month || (now.month == d.month && now.day < d.day)) {
+        age -= 1;
+      }
+      return '$age';
+    } catch (_) {
+      return 'חסר';
+    }
+  }
+}
+
+class _CoachCalendarStatus extends ConsumerWidget {
+  const _CoachCalendarStatus();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final status = ref.watch(calendarStatusProvider).valueOrNull;
+    if (status == null) {
+      return const SizedBox(
+        height: 24,
+        child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+      );
+    }
+    if (status.mock) {
+      return Container(
+        key: const Key('calendar-mock'),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: Colors.amber.shade100,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: const Text(
+          '🛠 יומן Google במצב סימולציה (פיתוח)',
+          textAlign: TextAlign.center,
+        ),
+      );
+    }
+    if (status.connected) {
+      return const Text(
+        '✓ יומן Google מחובר',
+        key: Key('calendar-connected'),
+      );
+    }
+    return FilledButton.tonalIcon(
+      key: const Key('connect-calendar-button'),
+      icon: const Icon(Icons.calendar_today),
+      label: const Text('חבר יומן Google'),
+      onPressed: () async {
+        try {
+          final url = await ref.read(calendarRepositoryProvider).getAuthUrl();
+          await ref.read(urlOpenerProvider).open(Uri.parse(url));
+        } catch (e) {
+          if (!context.mounted) return;
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('שגיאה: $e')),
+          );
+        }
+      },
     );
   }
 }

--- a/mobile/lib/features/profile/profile_screen.dart
+++ b/mobile/lib/features/profile/profile_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../design/spacing.dart';
+import '../../design/widgets.dart';
+import '../../theme.dart';
 import '../../utils/url_opener.dart';
 import '../auth/auth_repository.dart';
 import '../auth/login_screen.dart';
@@ -57,16 +60,16 @@ class ProfileScreen extends ConsumerWidget {
           ),
         ),
         data: (profile) => ListView(
-          padding: const EdgeInsets.all(20),
+          padding: const EdgeInsets.all(AppSpacing.lg),
           children: [
             _IdentityCard(profile: profile),
-            const SizedBox(height: 16),
+            const SizedBox(height: AppSpacing.lg),
             if (profile.role == 'trainee') ...[
               _TraineePreviewCard(),
-              const SizedBox(height: 16),
+              const SizedBox(height: AppSpacing.md),
               FilledButton.icon(
                 key: const Key('edit-profile-button'),
-                icon: const Icon(Icons.edit),
+                icon: const Icon(Icons.edit_outlined),
                 label: const Text('ערוך פרופיל'),
                 onPressed: () => Navigator.of(context).push(
                   MaterialPageRoute(
@@ -78,13 +81,13 @@ class ProfileScreen extends ConsumerWidget {
             if (profile.role == 'coach') ...[
               FilledButton.tonalIcon(
                 key: const Key('coach-settings-link'),
-                icon: const Icon(Icons.settings),
+                icon: const Icon(Icons.settings_outlined),
                 label: const Text('הגדרות מאמן'),
                 onPressed: () => Navigator.of(context).push(
                   MaterialPageRoute(builder: (_) => const CoachSettingsScreen()),
                 ),
               ),
-              const SizedBox(height: 12),
+              const SizedBox(height: AppSpacing.sm),
               const _CoachCalendarStatus(),
             ],
           ],
@@ -101,48 +104,56 @@ class _IdentityCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Card(
-      elevation: 0,
-      color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: Padding(
-        padding: const EdgeInsets.all(20),
-        child: Row(
-          children: [
-            CircleAvatar(
-              radius: 32,
-              backgroundColor: theme.colorScheme.primaryContainer,
-              child: Text(
-                profile.name.isNotEmpty ? profile.name.characters.first : '?',
-                style: theme.textTheme.headlineSmall?.copyWith(
-                  color: theme.colorScheme.onPrimaryContainer,
-                ),
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        vertical: AppSpacing.lg,
+        horizontal: AppSpacing.md,
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 64,
+            height: 64,
+            decoration: BoxDecoration(
+              gradient: const LinearGradient(
+                colors: [BrandColors.teal, BrandColors.tealDark],
+                begin: Alignment.topRight,
+                end: Alignment.bottomLeft,
+              ),
+              borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
+            ),
+            alignment: Alignment.center,
+            child: Text(
+              profile.name.isNotEmpty ? profile.name.characters.first : '?',
+              style: theme.textTheme.headlineMedium?.copyWith(
+                color: Colors.white,
+                fontWeight: FontWeight.w800,
               ),
             ),
-            const SizedBox(width: 16),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(profile.name,
-                      key: const Key('profile-name'),
-                      style: theme.textTheme.headlineSmall),
-                  const SizedBox(height: 4),
-                  Text(roleLabel(profile.role),
-                      key: const Key('profile-role'),
-                      style: theme.textTheme.titleSmall?.copyWith(
-                        color: theme.colorScheme.primary,
-                      )),
-                  const SizedBox(height: 2),
-                  Text(profile.email,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      )),
-                ],
-              ),
+          ),
+          const SizedBox(width: AppSpacing.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(profile.name,
+                    key: const Key('profile-name'),
+                    style: theme.textTheme.headlineSmall),
+                const SizedBox(height: 2),
+                Text(roleLabel(profile.role),
+                    key: const Key('profile-role'),
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: BrandColors.teal,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0.3,
+                    )),
+                const SizedBox(height: AppSpacing.xxs),
+                Text(profile.email,
+                    style: theme.textTheme.bodySmall),
+              ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -152,58 +163,41 @@ class _TraineePreviewCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final async = ref.watch(traineeProfileProvider);
-    return Card(
+    return Container(
       key: const Key('trainee-preview-card'),
-      elevation: 0,
-      shape: RoundedRectangleBorder(
-        side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
-        borderRadius: BorderRadius.circular(16),
+      decoration: BoxDecoration(
+        color: BrandColors.surface,
+        borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
+        border: Border.all(color: BrandColors.line),
       ),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: async.when(
-          loading: () => const SizedBox(
-            height: 100,
-            child: Center(child: CircularProgressIndicator()),
-          ),
-          error: (e, _) => Text('שגיאה: $e'),
-          data: (tp) => Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('פרטי המתאמן',
-                  style: Theme.of(context).textTheme.titleMedium),
-              const SizedBox(height: 12),
-              _row(Icons.phone, 'טלפון', tp.phone ?? 'חסר'),
-              _row(Icons.cake_outlined, 'גיל', _ageText(tp.dateOfBirth)),
-              _row(Icons.height, 'גובה',
-                  tp.heightCm == null ? 'חסר' : '${tp.heightCm} ס״מ'),
-              _row(Icons.monitor_weight_outlined, 'משקל',
-                  tp.weightKg == null ? 'חסר' : '${tp.weightKg} ק״ג'),
-              _row(Icons.flag_outlined, 'מטרות', tp.goals ?? 'חסר'),
-            ],
-          ),
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: async.when(
+        loading: () => const SizedBox(
+          height: 96,
+          child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+        ),
+        error: (e, _) => Text('שגיאה: $e'),
+        data: (tp) => Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SectionHeader('פרטים אישיים'),
+            DataGrid(children: [
+              InfoRow(icon: Icons.cake_outlined, label: 'גיל', value: _ageText(tp.dateOfBirth)),
+              InfoRow(icon: Icons.phone_outlined, label: 'טלפון', value: tp.phone),
+              InfoRow(icon: Icons.height, label: 'גובה', value: tp.heightCm == null ? null : '${tp.heightCm} ס״מ'),
+              InfoRow(icon: Icons.monitor_weight_outlined, label: 'משקל', value: tp.weightKg == null ? null : '${tp.weightKg} ק״ג'),
+            ]),
+            const SizedBox(height: AppSpacing.md),
+            const SectionHeader('מטרות'),
+            InfoRow(icon: Icons.flag_outlined, label: 'מטרות אימון', value: tp.goals),
+          ],
         ),
       ),
     );
   }
 
-  Widget _row(IconData icon, String label, String value) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 6),
-      child: Row(
-        children: [
-          Icon(icon, size: 20),
-          const SizedBox(width: 12),
-          Text('$label:'),
-          const SizedBox(width: 8),
-          Expanded(child: Text(value, textAlign: TextAlign.start)),
-        ],
-      ),
-    );
-  }
-
-  String _ageText(String? dob) {
-    if (dob == null) return 'חסר';
+  String? _ageText(String? dob) {
+    if (dob == null) return null;
     try {
       final d = DateTime.parse(dob);
       final now = DateTime.now();
@@ -213,7 +207,7 @@ class _TraineePreviewCard extends ConsumerWidget {
       }
       return '$age';
     } catch (_) {
-      return 'חסר';
+      return null;
     }
   }
 }
@@ -268,3 +262,4 @@ class _CoachCalendarStatus extends ConsumerWidget {
     );
   }
 }
+

--- a/mobile/lib/features/profile/trainee_profile.dart
+++ b/mobile/lib/features/profile/trainee_profile.dart
@@ -1,0 +1,64 @@
+/// The trainee-specific fields stored in `trainee_profile` (Phase 14+18).
+/// Mirrors the JSON shape returned by `/api/me/profile`.
+class TraineeProfile {
+  final String? phone;
+  final String? introText;
+  final String? photoUrl;
+  final String? dateOfBirth; // YYYY-MM-DD
+  final int? heightCm;
+  final int? weightKg;
+  final String? goals;
+  final String? medical;
+
+  const TraineeProfile({
+    this.phone,
+    this.introText,
+    this.photoUrl,
+    this.dateOfBirth,
+    this.heightCm,
+    this.weightKg,
+    this.goals,
+    this.medical,
+  });
+
+  factory TraineeProfile.fromJson(Map<String, dynamic> json) => TraineeProfile(
+        phone: json['phone'] as String?,
+        introText: json['introText'] as String?,
+        photoUrl: json['photoUrl'] as String?,
+        dateOfBirth: json['dateOfBirth'] as String?,
+        heightCm: (json['heightCm'] as num?)?.toInt(),
+        weightKg: (json['weightKg'] as num?)?.toInt(),
+        goals: json['goals'] as String?,
+        medical: json['medical'] as String?,
+      );
+}
+
+/// A partial update payload. Only non-null fields are sent.
+class TraineeProfilePatch {
+  final String? phone;
+  final String? dateOfBirth;
+  final int? heightCm;
+  final int? weightKg;
+  final String? goals;
+  final String? medical;
+
+  const TraineeProfilePatch({
+    this.phone,
+    this.dateOfBirth,
+    this.heightCm,
+    this.weightKg,
+    this.goals,
+    this.medical,
+  });
+
+  Map<String, dynamic> toJson() {
+    final m = <String, dynamic>{};
+    if (phone != null) m['phone'] = phone;
+    if (dateOfBirth != null) m['dateOfBirth'] = dateOfBirth;
+    if (heightCm != null) m['heightCm'] = heightCm;
+    if (weightKg != null) m['weightKg'] = weightKg;
+    if (goals != null) m['goals'] = goals;
+    if (medical != null) m['medical'] = medical;
+    return m;
+  }
+}

--- a/mobile/lib/features/profile/trainee_profile_editor_screen.dart
+++ b/mobile/lib/features/profile/trainee_profile_editor_screen.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'trainee_profile.dart';
+import 'trainee_profile_repository.dart';
+
+class TraineeProfileEditorScreen extends ConsumerStatefulWidget {
+  const TraineeProfileEditorScreen({super.key});
+
+  @override
+  ConsumerState<TraineeProfileEditorScreen> createState() =>
+      _TraineeProfileEditorScreenState();
+}
+
+class _TraineeProfileEditorScreenState
+    extends ConsumerState<TraineeProfileEditorScreen> {
+  final _phone = TextEditingController();
+  final _dob = TextEditingController();
+  final _height = TextEditingController();
+  final _weight = TextEditingController();
+  final _goals = TextEditingController();
+  final _medical = TextEditingController();
+
+  bool _initialised = false;
+  bool _saving = false;
+  String? _error;
+  String? _heightError;
+  String? _weightError;
+  String? _phoneError;
+
+  @override
+  void dispose() {
+    _phone.dispose();
+    _dob.dispose();
+    _height.dispose();
+    _weight.dispose();
+    _goals.dispose();
+    _medical.dispose();
+    super.dispose();
+  }
+
+  void _prefill(TraineeProfile p) {
+    _phone.text = p.phone ?? '';
+    _dob.text = p.dateOfBirth ?? '';
+    _height.text = p.heightCm?.toString() ?? '';
+    _weight.text = p.weightKg?.toString() ?? '';
+    _goals.text = p.goals ?? '';
+    _medical.text = p.medical ?? '';
+    _initialised = true;
+  }
+
+  TraineeProfilePatch? _buildPatch() {
+    setState(() {
+      _heightError = null;
+      _weightError = null;
+      _phoneError = null;
+    });
+
+    int? height;
+    if (_height.text.trim().isNotEmpty) {
+      height = int.tryParse(_height.text.trim());
+      if (height == null || height < 50 || height > 250) {
+        setState(() => _heightError = 'גובה לא תקין');
+        return null;
+      }
+    }
+
+    int? weight;
+    if (_weight.text.trim().isNotEmpty) {
+      weight = int.tryParse(_weight.text.trim());
+      if (weight == null || weight < 20 || weight > 400) {
+        setState(() => _weightError = 'משקל לא תקין');
+        return null;
+      }
+    }
+
+    String? phone;
+    if (_phone.text.trim().isNotEmpty) {
+      phone = _phone.text.trim();
+      if (!RegExp(r'^\+\d{8,15}$').hasMatch(phone)) {
+        setState(() => _phoneError = 'טלפון לא תקין (פורמט: +972...)');
+        return null;
+      }
+    }
+
+    String? dob;
+    if (_dob.text.trim().isNotEmpty) dob = _dob.text.trim();
+
+    return TraineeProfilePatch(
+      phone: phone,
+      dateOfBirth: dob,
+      heightCm: height,
+      weightKg: weight,
+      goals: _goals.text.trim().isEmpty ? null : _goals.text.trim(),
+      medical: _medical.text.trim().isEmpty ? null : _medical.text.trim(),
+    );
+  }
+
+  Future<void> _save() async {
+    final patch = _buildPatch();
+    if (patch == null) return;
+
+    setState(() {
+      _saving = true;
+      _error = null;
+    });
+    try {
+      await ref.read(traineeProfileRepositoryProvider).update(patch);
+      ref.invalidate(traineeProfileProvider);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('נשמר')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final async = ref.watch(traineeProfileProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('עריכת פרופיל')),
+      body: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, _) => Center(
+          child: Text('שגיאה: $err', key: const Key('editor-fetch-error')),
+        ),
+        data: (profile) {
+          if (!_initialised) _prefill(profile);
+          return ListView(
+            padding: const EdgeInsets.all(20),
+            children: [
+              _section('פרטי קשר'),
+              TextField(
+                key: const Key('phone-field'),
+                controller: _phone,
+                keyboardType: TextInputType.phone,
+                decoration: InputDecoration(
+                  labelText: 'טלפון (E.164, +972...)',
+                  errorText: _phoneError,
+                ),
+              ),
+              const SizedBox(height: 16),
+              _section('פרטים אישיים'),
+              TextField(
+                key: const Key('dob-field'),
+                controller: _dob,
+                decoration: const InputDecoration(
+                  labelText: 'תאריך לידה (YYYY-MM-DD)',
+                ),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      key: const Key('height-field'),
+                      controller: _height,
+                      keyboardType: TextInputType.number,
+                      decoration: InputDecoration(
+                        labelText: 'גובה (ס״מ)',
+                        errorText: _heightError,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: TextField(
+                      key: const Key('weight-field'),
+                      controller: _weight,
+                      keyboardType: TextInputType.number,
+                      decoration: InputDecoration(
+                        labelText: 'משקל (ק״ג)',
+                        errorText: _weightError,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              _section('מטרות וביטחון'),
+              TextField(
+                key: const Key('goals-field'),
+                controller: _goals,
+                minLines: 2,
+                maxLines: 5,
+                decoration: const InputDecoration(
+                  labelText: 'מטרות האימון',
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                key: const Key('medical-field'),
+                controller: _medical,
+                minLines: 2,
+                maxLines: 5,
+                decoration: const InputDecoration(
+                  labelText: 'מידע רפואי / מגבלות',
+                ),
+              ),
+              const SizedBox(height: 24),
+              FilledButton(
+                key: const Key('save-button'),
+                onPressed: _saving ? null : _save,
+                child: Text(_saving ? 'שומר...' : 'שמירה'),
+              ),
+              if (_error != null) ...[
+                const SizedBox(height: 16),
+                Text(
+                  _error!,
+                  key: const Key('editor-error'),
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
+                ),
+              ],
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _section(String text) => Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: Text(
+          text,
+          style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                color: Theme.of(context).colorScheme.primary,
+                fontWeight: FontWeight.bold,
+              ),
+        ),
+      );
+}

--- a/mobile/lib/features/profile/trainee_profile_repository.dart
+++ b/mobile/lib/features/profile/trainee_profile_repository.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../utils/authed_http_client.dart';
+import 'trainee_profile.dart';
+
+abstract class TraineeProfileRepository {
+  Future<TraineeProfile> fetch();
+  Future<TraineeProfile> update(TraineeProfilePatch patch);
+}
+
+class HttpTraineeProfileRepository implements TraineeProfileRepository {
+  final AuthedHttpClient _http;
+  HttpTraineeProfileRepository(this._http);
+
+  @override
+  Future<TraineeProfile> fetch() async {
+    final json = await _http.get<Map<String, dynamic>>('/api/me/profile');
+    return TraineeProfile.fromJson(json['profile'] as Map<String, dynamic>);
+  }
+
+  @override
+  Future<TraineeProfile> update(TraineeProfilePatch patch) async {
+    final json = await _http.patch<Map<String, dynamic>>(
+      '/api/me/profile',
+      data: patch.toJson(),
+    );
+    return TraineeProfile.fromJson(json['profile'] as Map<String, dynamic>);
+  }
+}
+
+final traineeProfileRepositoryProvider = Provider<TraineeProfileRepository>(
+  (ref) => HttpTraineeProfileRepository(ref.watch(authedHttpProvider)),
+);
+
+final traineeProfileProvider = FutureProvider<TraineeProfile>(
+  (ref) => ref.watch(traineeProfileRepositoryProvider).fetch(),
+);

--- a/mobile/lib/features/slots/home_screen.dart
+++ b/mobile/lib/features/slots/home_screen.dart
@@ -199,6 +199,10 @@ class _WelcomeHero extends ConsumerWidget {
     final attendancePct = dashboard != null
         ? '${(dashboard.attendanceRate * 100).round()}%'
         : '—';
+    final streak = dashboard != null && dashboard.currentStreak > 0
+        ? '🔥 ${dashboard.currentStreak}'
+        : '—';
+    final monthsSince = dashboard?.memberSinceMonths ?? 0;
 
     return Container(
       width: double.infinity,
@@ -228,6 +232,18 @@ class _WelcomeHero extends ConsumerWidget {
                   color: Colors.white,
                 ),
           ),
+          if (monthsSince > 0) ...[
+            const SizedBox(height: 4),
+            Text(
+              monthsSince == 1
+                  ? 'חבר/ה כבר חודש'
+                  : 'חבר/ה כבר $monthsSince חודשים',
+              key: const Key('member-since'),
+              style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                    color: Colors.white.withValues(alpha: 0.85),
+                  ),
+            ),
+          ],
           const SizedBox(height: 16),
           Row(
             children: [
@@ -242,11 +258,15 @@ class _WelcomeHero extends ConsumerWidget {
               ),
               const SizedBox(width: 10),
               _StatBadge(
-                value: next ?? '—',
-                label: 'האימון הבא',
+                value: streak,
+                label: 'רצף',
               ),
             ],
           ),
+          if (next != null) ...[
+            const SizedBox(height: 10),
+            _NextSessionPill(label: next),
+          ],
           const SizedBox(height: 16),
           _QuickActions(),
         ],
@@ -267,6 +287,37 @@ class _WelcomeHero extends ConsumerWidget {
     if (diff.inHours < 24) return 'בעוד ${diff.inHours}ש׳';
     if (diff.inDays < 7) return 'בעוד ${diff.inDays} ימים';
     return '${upcoming.first.value.day}.${upcoming.first.value.month}';
+  }
+}
+
+class _NextSessionPill extends StatelessWidget {
+  final String label;
+  const _NextSessionPill({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.18),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.calendar_today, size: 14, color: Colors.white),
+          const SizedBox(width: 6),
+          Text(
+            'האימון הבא: $label',
+            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/mobile/lib/features/slots/home_screen.dart
+++ b/mobile/lib/features/slots/home_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../design/spacing.dart';
+import '../../design/widgets.dart';
 import '../../theme.dart';
 import '../../utils/week_dates.dart';
 import '../bookings/booking.dart';
@@ -247,30 +249,33 @@ class _WelcomeHero extends ConsumerWidget {
                   ),
             ),
           ],
-          const SizedBox(height: 16),
+          const SizedBox(height: AppSpacing.md),
           Row(
             children: [
-              _StatBadge(
+              HeroStat(
                 value: '${confirmed.length}',
                 label: 'אימונים השבוע',
+                accent: Colors.white,
               ),
-              const SizedBox(width: 10),
-              _StatBadge(
+              const SizedBox(width: AppSpacing.sm),
+              HeroStat(
                 value: attendancePct,
                 label: 'נוכחות',
+                accent: BrandColors.orange,
               ),
-              const SizedBox(width: 10),
-              _StatBadge(
+              const SizedBox(width: AppSpacing.sm),
+              HeroStat(
                 value: streak,
                 label: 'רצף',
+                accent: BrandColors.orange,
               ),
             ],
           ),
           if (next != null) ...[
-            const SizedBox(height: 10),
+            const SizedBox(height: AppSpacing.sm),
             _NextSessionPill(label: next),
           ],
-          const SizedBox(height: 16),
+          const SizedBox(height: AppSpacing.md),
           _QuickActions(),
         ],
       ),
@@ -300,11 +305,13 @@ class _NextSessionPill extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: AppSpacing.xs,
+      ),
       decoration: BoxDecoration(
-        color: Colors.white.withValues(alpha: 0.18),
-        borderRadius: BorderRadius.circular(999),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.3)),
+        color: Colors.white.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(AppSpacing.radiusPill),
       ),
       child: Row(
         mainAxisSize: MainAxisSize.min,
@@ -319,40 +326,6 @@ class _NextSessionPill extends StatelessWidget {
                 ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _StatBadge extends StatelessWidget {
-  final String value;
-  final String label;
-  const _StatBadge({required this.value, required this.label});
-
-  @override
-  Widget build(BuildContext context) {
-    return Expanded(
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-        decoration: BoxDecoration(
-          color: Colors.white.withValues(alpha: 0.22),
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: Colors.white.withValues(alpha: 0.25)),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(value,
-                style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      color: Colors.white,
-                      fontWeight: FontWeight.w800,
-                    )),
-            Text(label,
-                style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                      color: Colors.white.withValues(alpha: 0.85),
-                    )),
-          ],
-        ),
       ),
     );
   }

--- a/mobile/lib/features/slots/home_screen.dart
+++ b/mobile/lib/features/slots/home_screen.dart
@@ -8,6 +8,7 @@ import '../bookings/booking_repository.dart';
 import '../bookings/cancel_request_sheet.dart';
 import '../coach/contact_coach_card.dart';
 import '../dashboard/dashboard_repository.dart';
+import '../history/history_screen.dart';
 import '../profile/profile_repository.dart';
 import '../profile/profile_screen.dart';
 import 'slot.dart';
@@ -371,11 +372,9 @@ class _QuickActions extends ConsumerWidget {
         _QuickActionChip(
           icon: Icons.history,
           label: 'היסטוריה',
-          onTap: () {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('היסטוריה תופיע בקרוב')),
-            );
-          },
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const HistoryScreen()),
+          ),
         ),
         const SizedBox(width: 10),
         _QuickActionChip(

--- a/mobile/lib/features/slots/home_screen.dart
+++ b/mobile/lib/features/slots/home_screen.dart
@@ -6,6 +6,7 @@ import '../../utils/week_dates.dart';
 import '../bookings/booking.dart';
 import '../bookings/booking_repository.dart';
 import '../bookings/cancel_request_sheet.dart';
+import '../coach/coach_about_card.dart';
 import '../coach/contact_coach_card.dart';
 import '../dashboard/dashboard_repository.dart';
 import '../history/history_screen.dart';
@@ -114,6 +115,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                 _WelcomeHero(now: widget.now),
+                const CoachAboutCard(),
                 const _CoachNoteCard(),
                 const _UpcomingSessionsCard(),
                 const _MyBookingsSection(),

--- a/mobile/test/features/coach/change_requests_screen_test.dart
+++ b/mobile/test/features/coach/change_requests_screen_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:velofit/features/coach/change_requests_repository.dart';
+import 'package:velofit/features/coach/change_requests_screen.dart';
+
+class _FakeRepo extends Mock implements ChangeRequestsRepository {}
+
+Widget _harness(ChangeRequestsRepository repo) => ProviderScope(
+      overrides: [changeRequestsRepositoryProvider.overrideWithValue(repo)],
+      child: MaterialApp(
+        builder: (context, child) => Directionality(
+          textDirection: TextDirection.rtl,
+          child: child ?? const SizedBox.shrink(),
+        ),
+        home: const ChangeRequestsScreen(),
+      ),
+    );
+
+void main() {
+  group('ChangeRequestsScreen', () {
+    testWidgets('shows empty placeholder', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('change-requests-empty')), findsOneWidget);
+      expect(find.text('אין בקשות שינוי פתוחות'), findsOneWidget);
+    });
+
+    testWidgets('renders cancel + reschedule requests', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer((_) async => const [
+            ChangeRequest(
+              id: 'r1',
+              requestedAt: '2026-04-08T10:00:00Z',
+              reason: 'חולה',
+              traineeId: 't1',
+              traineeName: 'יעל',
+              fromSlotStartsAt: '2026-04-09T07:00:00Z',
+              toSlotStartsAt: null,
+            ),
+            ChangeRequest(
+              id: 'r2',
+              requestedAt: '2026-04-08T11:00:00Z',
+              reason: '',
+              traineeId: 't2',
+              traineeName: 'דנה',
+              fromSlotStartsAt: '2026-04-10T07:00:00Z',
+              toSlotStartsAt: '2026-04-11T07:00:00Z',
+            ),
+          ]);
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('cr-tile-r1')), findsOneWidget);
+      expect(find.byKey(const Key('cr-tile-r2')), findsOneWidget);
+      expect(find.text('יעל'), findsOneWidget);
+      expect(find.text('דנה'), findsOneWidget);
+      expect(find.text('חולה'), findsOneWidget);
+    });
+
+    testWidgets('tap approve → repo.decide(approve) + invalidate', (tester) async {
+      final repo = _FakeRepo();
+      var fetchCount = 0;
+      when(() => repo.fetch()).thenAnswer((_) async {
+        fetchCount++;
+        if (fetchCount == 1) {
+          return const [
+            ChangeRequest(
+              id: 'r1',
+              requestedAt: '2026-04-08T10:00:00Z',
+              reason: '',
+              traineeId: 't1',
+              traineeName: 'יעל',
+              fromSlotStartsAt: '2026-04-09T07:00:00Z',
+              toSlotStartsAt: null,
+            ),
+          ];
+        }
+        return [];
+      });
+      when(() => repo.decide(any(),
+          decision: any(named: 'decision'),
+          note: any(named: 'note'))).thenAnswer((_) async {});
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('approve-r1')));
+      await tester.pumpAndSettle();
+
+      verify(() => repo.decide('r1', decision: 'approve')).called(1);
+      expect(find.text('אושר'), findsOneWidget);
+    });
+
+    testWidgets('tap reject → repo.decide(reject)', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer((_) async => const [
+            ChangeRequest(
+              id: 'r1',
+              requestedAt: '2026-04-08T10:00:00Z',
+              reason: '',
+              traineeId: 't1',
+              traineeName: 'יעל',
+              fromSlotStartsAt: '2026-04-09T07:00:00Z',
+              toSlotStartsAt: null,
+            ),
+          ]);
+      when(() => repo.decide(any(),
+          decision: any(named: 'decision'),
+          note: any(named: 'note'))).thenAnswer((_) async {});
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('reject-r1')));
+      await tester.pumpAndSettle();
+
+      verify(() => repo.decide('r1', decision: 'reject')).called(1);
+      expect(find.text('נדחה'), findsOneWidget);
+    });
+
+    testWidgets('error path shows error widget', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenThrow(Exception('boom'));
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('change-requests-error')), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/features/coach/coach_about_card_test.dart
+++ b/mobile/test/features/coach/coach_about_card_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:velofit/features/coach/coach_about_card.dart';
+import 'package:velofit/features/coach/coach_info.dart';
+import 'package:velofit/features/coach/coach_info_repository.dart';
+
+class _FakeRepo extends Mock implements CoachInfoRepository {}
+
+Widget _harness(CoachInfoRepository repo) => ProviderScope(
+      overrides: [coachInfoRepositoryProvider.overrideWithValue(repo)],
+      child: MaterialApp(
+        builder: (context, child) => Directionality(
+          textDirection: TextDirection.rtl,
+          child: child ?? const SizedBox.shrink(),
+        ),
+        home: const Scaffold(body: CoachAboutCard()),
+      ),
+    );
+
+void main() {
+  group('CoachAboutCard', () {
+    testWidgets('renders name + specialty pill + years pill + bio', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer((_) async => const CoachInfo(
+            name: 'דני אמסלם',
+            contactPhone: '+972501234567',
+            bio: 'מאמן מנוסה במיוחד',
+            specialty: 'כוח',
+            yearsExperience: 8,
+          ));
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('coach-about-card')), findsOneWidget);
+      expect(find.text('דני אמסלם'), findsOneWidget);
+      expect(find.text('כוח'), findsOneWidget);
+      expect(find.text('8 שנות ניסיון'), findsOneWidget);
+      expect(find.text('מאמן מנוסה במיוחד'), findsOneWidget);
+    });
+
+    testWidgets('renders nothing when coach has no bio / specialty / years',
+        (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer(
+        (_) async => const CoachInfo(name: 'דני', contactPhone: '+972501234567'),
+      );
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('coach-about-card')), findsNothing);
+    });
+
+    testWidgets('renders nothing when CoachInfo is null', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer((_) async => null);
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('coach-about-card')), findsNothing);
+    });
+  });
+}

--- a/mobile/test/features/coach/coach_dashboard_repository_test.dart
+++ b/mobile/test/features/coach/coach_dashboard_repository_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:velofit/features/coach/coach_dashboard_repository.dart';
+
+void main() {
+  group('CoachDashboardView.fromJson', () {
+    test('parses all counts including roster length', () {
+      final view = CoachDashboardView.fromJson({
+        'pendingApprovals': 2,
+        'pendingChangeRequests': 1,
+        'noShowsThisWeek': 3,
+        'todayRoster': [
+          {'bookingId': 'b1'},
+          {'bookingId': 'b2'},
+        ],
+        'urgentRequests': [],
+      });
+      expect(view.pendingApprovals, 2);
+      expect(view.pendingChangeRequests, 1);
+      expect(view.noShowsThisWeek, 3);
+      expect(view.todayRosterCount, 2);
+    });
+
+    test('defaults missing fields to 0', () {
+      final view = CoachDashboardView.fromJson({});
+      expect(view.pendingApprovals, 0);
+      expect(view.pendingChangeRequests, 0);
+      expect(view.noShowsThisWeek, 0);
+      expect(view.todayRosterCount, 0);
+    });
+  });
+}

--- a/mobile/test/features/coach/coach_settings_screen_test.dart
+++ b/mobile/test/features/coach/coach_settings_screen_test.dart
@@ -9,6 +9,8 @@ import 'package:velofit/features/coach/coach_settings_screen.dart';
 
 class _FakeCoachInfoRepo extends Mock implements CoachInfoRepository {}
 
+class _FakePatch extends Fake implements CoachInfoPatch {}
+
 Widget _harness({required CoachInfoRepository repo}) => ProviderScope(
       overrides: [coachInfoRepositoryProvider.overrideWithValue(repo)],
       child: MaterialApp(
@@ -20,38 +22,91 @@ Widget _harness({required CoachInfoRepository repo}) => ProviderScope(
       ),
     );
 
+Future<void> _scrollToSave(WidgetTester tester) async {
+  await tester.dragUntilVisible(
+    find.byKey(const Key('contact-phone-save')),
+    find.byType(ListView),
+    const Offset(0, -50),
+  );
+  await tester.pumpAndSettle();
+}
+
 void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakePatch());
+  });
+
   group('CoachSettingsScreen', () {
-    testWidgets('prefills with current contact_phone', (tester) async {
+    testWidgets('prefills with current contact_phone + bio + specialty + years',
+        (tester) async {
       final repo = _FakeCoachInfoRepo();
       when(() => repo.fetch()).thenAnswer((_) async => const CoachInfo(
             name: 'דני',
             contactPhone: '+972501234567',
+            bio: 'מאמן מנוסה',
+            specialty: 'כוח',
+            yearsExperience: 8,
           ));
 
       await tester.pumpWidget(_harness(repo: repo));
       await tester.pumpAndSettle();
 
-      expect(
-        tester.widget<TextField>(find.byKey(const Key('contact-phone-field'))).controller!.text,
-        '+972501234567',
-      );
+      String text(String key) =>
+          tester.widget<TextField>(find.byKey(Key(key))).controller!.text;
+
+      expect(text('contact-phone-field'), '+972501234567');
+      expect(text('coach-bio-field'), 'מאמן מנוסה');
+      expect(text('coach-specialty-field'), 'כוח');
+      expect(text('coach-years-field'), '8');
     });
 
-    testWidgets('save → updateContactPhone fired with input', (tester) async {
+    testWidgets('save → repo.update fired with patch', (tester) async {
       final repo = _FakeCoachInfoRepo();
-      when(() => repo.fetch()).thenAnswer((_) async => const CoachInfo(name: 'דני', contactPhone: null));
-      when(() => repo.updateContactPhone(any())).thenAnswer((_) async {});
+      CoachInfoPatch? captured;
+      when(() => repo.fetch()).thenAnswer(
+        (_) async => const CoachInfo(name: 'דני', contactPhone: null),
+      );
+      when(() => repo.update(any())).thenAnswer((inv) async {
+        captured = inv.positionalArguments.first as CoachInfoPatch;
+      });
 
       await tester.pumpWidget(_harness(repo: repo));
       await tester.pumpAndSettle();
 
       await tester.enterText(find.byKey(const Key('contact-phone-field')), '+972509998888');
+      await tester.enterText(find.byKey(const Key('coach-specialty-field')), 'שיקום');
+      await tester.enterText(find.byKey(const Key('coach-years-field')), '5');
+      await tester.enterText(find.byKey(const Key('coach-bio-field')), 'אוהב לעזור');
+      await _scrollToSave(tester);
       await tester.tap(find.byKey(const Key('contact-phone-save')));
       await tester.pumpAndSettle();
 
-      verify(() => repo.updateContactPhone('+972509998888')).called(1);
+      expect(captured, isNotNull);
+      expect(captured!.contactPhone, '+972509998888');
+      expect(captured!.specialty, 'שיקום');
+      expect(captured!.yearsExperience, 5);
+      expect(captured!.bio, 'אוהב לעזור');
       expect(find.text('נשמר'), findsOneWidget);
+    });
+
+    testWidgets('invalid years shows inline error and does not call repo',
+        (tester) async {
+      final repo = _FakeCoachInfoRepo();
+      when(() => repo.fetch()).thenAnswer(
+        (_) async => const CoachInfo(name: 'דני', contactPhone: null),
+      );
+      when(() => repo.update(any())).thenAnswer((_) async {});
+
+      await tester.pumpWidget(_harness(repo: repo));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byKey(const Key('coach-years-field')), '999');
+      await _scrollToSave(tester);
+      await tester.tap(find.byKey(const Key('contact-phone-save')));
+      await tester.pumpAndSettle();
+
+      verifyNever(() => repo.update(any()));
+      expect(find.text('מספר לא תקין (0-80)'), findsOneWidget);
     });
   });
 }

--- a/mobile/test/features/coach/coach_trainee_detail_screen_test.dart
+++ b/mobile/test/features/coach/coach_trainee_detail_screen_test.dart
@@ -78,8 +78,11 @@ void main() {
       await tester.pumpWidget(_harness(repo));
       await tester.pumpAndSettle();
 
-      expect(find.text('2026-04-10  10:00'), findsOneWidget);
-      expect(find.text('2026-04-08  14:00'), findsOneWidget);
+      // New layout splits time + date.
+      expect(find.text('10:00'), findsOneWidget);
+      expect(find.text('14:00'), findsOneWidget);
+      expect(find.text('10.4'), findsOneWidget);
+      expect(find.text('8.4'), findsOneWidget);
     });
 
     testWidgets('empty sessions shows placeholder', (tester) async {

--- a/mobile/test/features/coach/coach_trainee_detail_screen_test.dart
+++ b/mobile/test/features/coach/coach_trainee_detail_screen_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:velofit/features/coach/coach_trainee_detail_screen.dart';
+import 'package:velofit/features/coach/trainee_detail_repository.dart';
+
+class _FakeRepo extends Mock implements TraineeDetailRepository {}
+
+Widget _harness(TraineeDetailRepository repo) => ProviderScope(
+      overrides: [traineeDetailRepositoryProvider.overrideWithValue(repo)],
+      child: MaterialApp(
+        builder: (context, child) => Directionality(
+          textDirection: TextDirection.rtl,
+          child: child ?? const SizedBox.shrink(),
+        ),
+        home: const CoachTraineeDetailScreen(traineeId: 't1'),
+      ),
+    );
+
+TraineeDetailView _viewWith({TraineeBio? bio, List<TraineeSession>? sessions, bool active = true}) =>
+    TraineeDetailView(
+      id: 't1',
+      name: 'יעל כהן',
+      isActive: active,
+      bio: bio ?? const TraineeBio(),
+      sessions: sessions ?? const [],
+      weekBookingsCount: 2,
+    );
+
+void main() {
+  group('CoachTraineeDetailScreen', () {
+    testWidgets('renders name + Hebrew status + bio fields', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch('t1')).thenAnswer((_) async => _viewWith(
+            bio: const TraineeBio(
+              phone: '+972501234567',
+              dateOfBirth: '1992-04-08',
+              heightCm: 168,
+              weightKg: 65,
+              goals: 'לרדת 5 ק״ג',
+              medical: 'אין',
+            ),
+          ));
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.text('יעל כהן'), findsWidgets);
+      expect(find.text('פעיל'), findsOneWidget);
+      expect(find.text('168 ס״מ'), findsOneWidget);
+      expect(find.text('65 ק״ג'), findsOneWidget);
+      expect(find.text('לרדת 5 ק״ג'), findsOneWidget);
+      expect(find.text('+972501234567'), findsOneWidget);
+    });
+
+    testWidgets('renders חסר for missing bio fields', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch('t1')).thenAnswer((_) async => _viewWith());
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('bio-card')), findsOneWidget);
+      expect(find.text('חסר'), findsWidgets);
+    });
+
+    testWidgets('renders past sessions', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch('t1')).thenAnswer((_) async => _viewWith(
+            sessions: const [
+              TraineeSession(bookingId: 'b1', date: '2026-04-10', startTime: '10:00'),
+              TraineeSession(bookingId: 'b2', date: '2026-04-08', startTime: '14:00'),
+            ],
+          ));
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.text('2026-04-10  10:00'), findsOneWidget);
+      expect(find.text('2026-04-08  14:00'), findsOneWidget);
+    });
+
+    testWidgets('empty sessions shows placeholder', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch('t1')).thenAnswer((_) async => _viewWith());
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('sessions-empty')), findsOneWidget);
+    });
+
+    testWidgets('shows מושבת label when inactive', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch('t1')).thenAnswer((_) async => _viewWith(active: false));
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.text('מושבת'), findsOneWidget);
+    });
+
+    testWidgets('error path shows error widget', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch('t1')).thenThrow(Exception('boom'));
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('trainee-detail-error')), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/features/dashboard/dashboard_model_test.dart
+++ b/mobile/test/features/dashboard/dashboard_model_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:velofit/features/dashboard/dashboard_repository.dart';
+
+void main() {
+  group('TraineeDashboard.fromJson', () {
+    test('parses full payload including currentStreak + memberSinceDays', () {
+      final d = TraineeDashboard.fromJson({
+        'sessionsThisMonth': 4,
+        'pastConfirmed': 7,
+        'noShows': 1,
+        'attendanceRate': 0.875,
+        'currentStreak': 3,
+        'nextSessionAt': '2026-05-22T07:00:00.000Z',
+        'recentVisibleNote': null,
+        'remainingEdits': null,
+        'memberSinceDays': 97,
+      });
+      expect(d.sessionsThisMonth, 4);
+      expect(d.pastConfirmed, 7);
+      expect(d.noShows, 1);
+      expect(d.attendanceRate, closeTo(0.875, 1e-9));
+      expect(d.currentStreak, 3);
+      expect(d.memberSinceDays, 97);
+      expect(d.nextSessionAt, '2026-05-22T07:00:00.000Z');
+      expect(d.recentVisibleNote, isNull);
+    });
+
+    test('defaults missing fields to 0', () {
+      final d = TraineeDashboard.fromJson({});
+      expect(d.currentStreak, 0);
+      expect(d.memberSinceDays, 0);
+    });
+
+    test('memberSinceMonths derived from memberSinceDays', () {
+      // 365 days → 12 months
+      expect(TraineeDashboard.fromJson({'memberSinceDays': 365}).memberSinceMonths, 12);
+      // 45 days → 1 month (floor)
+      expect(TraineeDashboard.fromJson({'memberSinceDays': 45}).memberSinceMonths, 1);
+    });
+  });
+}

--- a/mobile/test/features/history/history_screen_test.dart
+++ b/mobile/test/features/history/history_screen_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:velofit/features/history/history_repository.dart';
+import 'package:velofit/features/history/history_screen.dart';
+
+class _FakeRepo extends Mock implements HistoryRepository {}
+
+Widget _harness(HistoryRepository repo) => ProviderScope(
+      overrides: [historyRepositoryProvider.overrideWithValue(repo)],
+      child: MaterialApp(
+        builder: (context, child) => Directionality(
+          textDirection: TextDirection.rtl,
+          child: child ?? const SizedBox.shrink(),
+        ),
+        home: const HistoryScreen(),
+      ),
+    );
+
+void main() {
+  group('HistoryScreen', () {
+    testWidgets('empty state shows Hebrew placeholder', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('history-empty')), findsOneWidget);
+      expect(find.text('עדיין אין היסטוריית אימונים'), findsOneWidget);
+    });
+
+    testWidgets('groups entries by month with Hebrew month names', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer((_) async => const [
+            HistoryEntry(
+              bookingId: 'b1',
+              slotId: 's1',
+              date: '2026-04-10',
+              startTime: '10:00',
+              status: 'confirmed',
+              startsAt: '2026-04-10T07:00:00.000Z',
+              isPast: true,
+            ),
+            HistoryEntry(
+              bookingId: 'b2',
+              slotId: 's2',
+              date: '2026-03-15',
+              startTime: '11:00',
+              status: 'no_show',
+              startsAt: '2026-03-15T08:00:00.000Z',
+              isPast: true,
+            ),
+          ]);
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.text('אפריל 2026'), findsOneWidget);
+      expect(find.text('מרץ 2026'), findsOneWidget);
+    });
+
+    testWidgets('renders status labels for confirmed/cancelled/no_show', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer((_) async => const [
+            HistoryEntry(
+              bookingId: 'b1',
+              slotId: 's1',
+              date: '2026-04-10',
+              startTime: '10:00',
+              status: 'confirmed',
+              startsAt: '2026-04-10T07:00:00.000Z',
+              isPast: true,
+            ),
+            HistoryEntry(
+              bookingId: 'b2',
+              slotId: 's2',
+              date: '2026-04-12',
+              startTime: '11:00',
+              status: 'cancelled',
+              startsAt: '2026-04-12T08:00:00.000Z',
+              isPast: true,
+            ),
+            HistoryEntry(
+              bookingId: 'b3',
+              slotId: 's3',
+              date: '2026-04-14',
+              startTime: '12:00',
+              status: 'no_show',
+              startsAt: '2026-04-14T09:00:00.000Z',
+              isPast: true,
+            ),
+          ]);
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.text('הושלם'), findsOneWidget);
+      expect(find.text('בוטל'), findsOneWidget);
+      expect(find.text('לא הגיע'), findsOneWidget);
+    });
+
+    testWidgets('shows error when fetch fails', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenThrow(Exception('boom'));
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('history-error')), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/features/profile/profile_screen_test.dart
+++ b/mobile/test/features/profile/profile_screen_test.dart
@@ -8,6 +8,8 @@ import 'package:velofit/features/coach/calendar_repository.dart' show CalendarRe
 import 'package:velofit/features/profile/profile.dart';
 import 'package:velofit/features/profile/profile_repository.dart';
 import 'package:velofit/features/profile/profile_screen.dart';
+import 'package:velofit/features/profile/trainee_profile.dart';
+import 'package:velofit/features/profile/trainee_profile_repository.dart';
 import 'package:velofit/utils/url_opener.dart';
 
 class _FakeProfileRepo extends Mock implements ProfileRepository {}
@@ -15,6 +17,8 @@ class _FakeProfileRepo extends Mock implements ProfileRepository {}
 class _FakeAuth extends Mock implements AuthRepository {}
 
 class _FakeCalendarRepo extends Mock implements CalendarRepository {}
+
+class _FakeTraineeProfileRepo extends Mock implements TraineeProfileRepository {}
 
 class _CapturingUrlOpener implements UrlOpener {
   final List<Uri> opened = [];
@@ -27,6 +31,7 @@ Widget _harness(
   AuthRepository? auth,
   CalendarRepository? calendar,
   UrlOpener? urlOpener,
+  TraineeProfileRepository? traineeProfileRepo,
 }) {
   final calRepo = calendar ?? _FakeCalendarRepo();
   if (calendar == null) {
@@ -34,11 +39,17 @@ Widget _harness(
       (_) async => const CalendarStatus(connected: false, mock: false),
     );
   }
+  final tpRepo = traineeProfileRepo ?? _FakeTraineeProfileRepo();
+  if (traineeProfileRepo == null) {
+    when(() => (tpRepo as _FakeTraineeProfileRepo).fetch())
+        .thenAnswer((_) async => const TraineeProfile());
+  }
   return ProviderScope(
     overrides: [
       profileRepositoryProvider.overrideWithValue(repo),
       if (auth != null) authRepositoryProvider.overrideWithValue(auth),
       calendarRepositoryProvider.overrideWithValue(calRepo),
+      traineeProfileRepositoryProvider.overrideWithValue(tpRepo),
       if (urlOpener != null) urlOpenerProvider.overrideWithValue(urlOpener),
     ],
     child: MaterialApp(
@@ -177,6 +188,84 @@ void main() {
 
       expect(opener.opened, hasLength(1));
       expect(opener.opened.first.toString(), 'https://accounts.google.com/o/oauth2/v2/auth?xxx');
+    });
+
+    testWidgets('trainee sees ערוך פרופיל button', (tester) async {
+      final repo = _FakeProfileRepo();
+      when(() => repo.fetchMe()).thenAnswer((_) async => const Profile(
+            id: 't1',
+            email: 't@example.com',
+            name: 'יעל',
+            role: 'trainee',
+          ));
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('edit-profile-button')), findsOneWidget);
+      expect(find.text('ערוך פרופיל'), findsOneWidget);
+    });
+
+    testWidgets('coach does NOT see ערוך פרופיל button', (tester) async {
+      final repo = _FakeProfileRepo();
+      when(() => repo.fetchMe()).thenAnswer((_) async => const Profile(
+            id: 'c1',
+            email: 'coach@example.com',
+            name: 'Coach',
+            role: 'coach',
+          ));
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('edit-profile-button')), findsNothing);
+    });
+
+    testWidgets('trainee preview shows phone, age (from dob), height, weight, goals',
+        (tester) async {
+      final repo = _FakeProfileRepo();
+      when(() => repo.fetchMe()).thenAnswer((_) async => const Profile(
+            id: 't1',
+            email: 't@example.com',
+            name: 'יעל',
+            role: 'trainee',
+          ));
+      final tp = _FakeTraineeProfileRepo();
+      when(() => tp.fetch()).thenAnswer((_) async => const TraineeProfile(
+            phone: '+972501234567',
+            dateOfBirth: '1992-04-08',
+            heightCm: 168,
+            weightKg: 65,
+            goals: 'לרדת 5 קילו',
+          ));
+
+      await tester.pumpWidget(_harness(repo, traineeProfileRepo: tp));
+      await tester.pumpAndSettle();
+
+      expect(find.text('+972501234567'), findsOneWidget);
+      expect(find.text('168 ס״מ'), findsOneWidget);
+      expect(find.text('65 ק״ג'), findsOneWidget);
+      expect(find.text('לרדת 5 קילו'), findsOneWidget);
+    });
+
+    testWidgets('trainee preview shows חסר fallback when fields empty',
+        (tester) async {
+      final repo = _FakeProfileRepo();
+      when(() => repo.fetchMe()).thenAnswer((_) async => const Profile(
+            id: 't1',
+            email: 't@example.com',
+            name: 'יעל',
+            role: 'trainee',
+          ));
+      final tp = _FakeTraineeProfileRepo();
+      when(() => tp.fetch()).thenAnswer((_) async => const TraineeProfile());
+
+      await tester.pumpWidget(_harness(repo, traineeProfileRepo: tp));
+      await tester.pumpAndSettle();
+
+      // Trainee preview section should be visible with placeholder values
+      expect(find.byKey(const Key('trainee-preview-card')), findsOneWidget);
+      expect(find.text('חסר'), findsWidgets);
     });
 
     testWidgets('sign-out button calls AuthRepository.signOut', (tester) async {

--- a/mobile/test/features/profile/trainee_profile_editor_screen_test.dart
+++ b/mobile/test/features/profile/trainee_profile_editor_screen_test.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:velofit/features/profile/trainee_profile.dart';
+import 'package:velofit/features/profile/trainee_profile_editor_screen.dart';
+import 'package:velofit/features/profile/trainee_profile_repository.dart';
+
+class _FakeRepo extends Mock implements TraineeProfileRepository {}
+
+class _FakePatch extends Fake implements TraineeProfilePatch {}
+
+Widget _harness(TraineeProfileRepository repo) => ProviderScope(
+      overrides: [
+        traineeProfileRepositoryProvider.overrideWithValue(repo),
+      ],
+      child: MaterialApp(
+        builder: (context, child) => Directionality(
+          textDirection: TextDirection.rtl,
+          child: child ?? const SizedBox.shrink(),
+        ),
+        home: const TraineeProfileEditorScreen(),
+      ),
+    );
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakePatch());
+  });
+
+  group('TraineeProfileEditorScreen', () {
+    testWidgets('prefills current values from server', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer((_) async => const TraineeProfile(
+            phone: '+972501234567',
+            dateOfBirth: '1992-04-08',
+            heightCm: 168,
+            weightKg: 65,
+            goals: 'לרדת 5 קילו',
+            medical: 'אין',
+          ));
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(_text(tester, 'phone-field'), '+972501234567');
+      expect(_text(tester, 'height-field'), '168');
+      expect(_text(tester, 'weight-field'), '65');
+      expect(_text(tester, 'goals-field'), 'לרדת 5 קילו');
+      expect(_text(tester, 'medical-field'), 'אין');
+      expect(_text(tester, 'dob-field'), '1992-04-08');
+    });
+
+    testWidgets('save → repo.update with edited fields', (tester) async {
+      final repo = _FakeRepo();
+      TraineeProfilePatch? captured;
+      when(() => repo.fetch()).thenAnswer((_) async => const TraineeProfile());
+      when(() => repo.update(any())).thenAnswer((inv) async {
+        captured = inv.positionalArguments.first as TraineeProfilePatch;
+        return const TraineeProfile();
+      });
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byKey(const Key('phone-field')), '+972500000000');
+      await tester.enterText(find.byKey(const Key('height-field')), '175');
+      await tester.enterText(find.byKey(const Key('weight-field')), '70');
+      await tester.enterText(find.byKey(const Key('goals-field')), 'חיטוב');
+      await _scrollToSave(tester);
+      await tester.tap(find.byKey(const Key('save-button')));
+      await tester.pumpAndSettle();
+
+      expect(captured, isNotNull);
+      expect(captured!.phone, '+972500000000');
+      expect(captured!.heightCm, 175);
+      expect(captured!.weightKg, 70);
+      expect(captured!.goals, 'חיטוב');
+    });
+
+    testWidgets('save shows snackbar on success', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer((_) async => const TraineeProfile());
+      when(() => repo.update(any())).thenAnswer((_) async => const TraineeProfile());
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      await _scrollToSave(tester);
+      await tester.tap(find.byKey(const Key('save-button')));
+      await tester.pump(); // queue snackbar
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('נשמר'), findsOneWidget);
+    });
+
+    testWidgets('save shows error message on failure', (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer((_) async => const TraineeProfile());
+      when(() => repo.update(any())).thenThrow(Exception('boom'));
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      await _scrollToSave(tester);
+      await tester.tap(find.byKey(const Key('save-button')));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('editor-error')), findsOneWidget);
+    });
+
+    testWidgets('invalid height shows inline validation error and does not call repo',
+        (tester) async {
+      final repo = _FakeRepo();
+      when(() => repo.fetch()).thenAnswer((_) async => const TraineeProfile());
+      when(() => repo.update(any())).thenAnswer((_) async => const TraineeProfile());
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byKey(const Key('height-field')), 'abc');
+      await _scrollToSave(tester);
+      await tester.tap(find.byKey(const Key('save-button')));
+      await tester.pumpAndSettle();
+
+      verifyNever(() => repo.update(any()));
+      expect(find.text('גובה לא תקין'), findsOneWidget);
+    });
+  });
+}
+
+String _text(WidgetTester t, String key) =>
+    t.widget<TextField>(find.byKey(Key(key))).controller!.text;
+
+Future<void> _scrollToSave(WidgetTester tester) async {
+  await tester.dragUntilVisible(
+    find.byKey(const Key('save-button')),
+    find.byType(ListView),
+    const Offset(0, -50),
+  );
+  await tester.pumpAndSettle();
+}

--- a/mobile/test/features/profile/trainee_profile_repository_test.dart
+++ b/mobile/test/features/profile/trainee_profile_repository_test.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:velofit/features/profile/trainee_profile.dart';
+import 'package:velofit/features/profile/trainee_profile_repository.dart';
+import 'package:velofit/utils/authed_http_client.dart';
+
+class _FakeHttp extends Mock implements AuthedHttpClient {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  group('HttpTraineeProfileRepository.fetch', () {
+    test('parses /api/me/profile response', () async {
+      final http = _FakeHttp();
+      when(() => http.get<Map<String, dynamic>>('/api/me/profile')).thenAnswer(
+        (_) async => {
+          'profile': {
+            'phone': '+972501234567',
+            'introText': 'הצגה עצמית',
+            'photoUrl': null,
+            'dateOfBirth': '1992-04-08',
+            'heightCm': 168,
+            'weightKg': 65,
+            'goals': 'לרדת 5 קילו',
+            'medical': 'אין',
+          }
+        },
+      );
+
+      final repo = HttpTraineeProfileRepository(http);
+      final p = await repo.fetch();
+
+      expect(p.phone, '+972501234567');
+      expect(p.dateOfBirth, '1992-04-08');
+      expect(p.heightCm, 168);
+      expect(p.weightKg, 65);
+      expect(p.goals, 'לרדת 5 קילו');
+      expect(p.medical, 'אין');
+    });
+
+    test('handles all-null payload', () async {
+      final http = _FakeHttp();
+      when(() => http.get<Map<String, dynamic>>('/api/me/profile')).thenAnswer(
+        (_) async => {
+          'profile': {
+            'phone': null,
+            'introText': null,
+            'photoUrl': null,
+            'dateOfBirth': null,
+            'heightCm': null,
+            'weightKg': null,
+            'goals': null,
+            'medical': null,
+          }
+        },
+      );
+
+      final p = await HttpTraineeProfileRepository(http).fetch();
+
+      expect(p.phone, isNull);
+      expect(p.heightCm, isNull);
+      expect(p.weightKg, isNull);
+      expect(p.dateOfBirth, isNull);
+      expect(p.goals, isNull);
+      expect(p.medical, isNull);
+    });
+  });
+
+  group('HttpTraineeProfileRepository.update', () {
+    test('PATCHes only the fields present in the patch', () async {
+      Map<String, dynamic>? sent;
+      final http = _FakeHttp();
+      when(() => http.patch<Map<String, dynamic>>(
+            '/api/me/profile',
+            data: any(named: 'data'),
+          )).thenAnswer((inv) async {
+        sent = inv.namedArguments[#data] as Map<String, dynamic>;
+        return {
+          'profile': {
+            'phone': '+972500000000',
+            'introText': null,
+            'photoUrl': null,
+            'dateOfBirth': null,
+            'heightCm': 170,
+            'weightKg': null,
+            'goals': null,
+            'medical': null,
+          }
+        };
+      });
+
+      final result = await HttpTraineeProfileRepository(http).update(
+        const TraineeProfilePatch(phone: '+972500000000', heightCm: 170),
+      );
+
+      expect(sent, {'phone': '+972500000000', 'heightCm': 170});
+      expect(result.phone, '+972500000000');
+      expect(result.heightCm, 170);
+    });
+
+    test('empty patch sends empty body', () async {
+      Map<String, dynamic>? sent;
+      final http = _FakeHttp();
+      when(() => http.patch<Map<String, dynamic>>(
+            '/api/me/profile',
+            data: any(named: 'data'),
+          )).thenAnswer((inv) async {
+        sent = inv.namedArguments[#data] as Map<String, dynamic>;
+        return {
+          'profile': {
+            'phone': null,
+            'introText': null,
+            'photoUrl': null,
+            'dateOfBirth': null,
+            'heightCm': null,
+            'weightKg': null,
+            'goals': null,
+            'medical': null,
+          }
+        };
+      });
+
+      await HttpTraineeProfileRepository(http).update(const TraineeProfilePatch());
+
+      expect(sent, <String, dynamic>{});
+    });
+  });
+}

--- a/mobile/test/features/slots/home_screen_test.dart
+++ b/mobile/test/features/slots/home_screen_test.dart
@@ -218,6 +218,7 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
+      await tester.ensureVisible(find.byKey(const Key('contact-coach-whatsapp')));
       await tester.tap(find.byKey(const Key('contact-coach-whatsapp')));
       await tester.pumpAndSettle();
 
@@ -259,6 +260,7 @@ void main() {
       ));
       await tester.pumpAndSettle();
 
+      await tester.ensureVisible(find.byKey(const Key('contact-coach-call')));
       await tester.tap(find.byKey(const Key('contact-coach-call')));
       await tester.pumpAndSettle();
 

--- a/src/app/api/admin/change-requests/__tests__/list.test.ts
+++ b/src/app/api/admin/change-requests/__tests__/list.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockJwtSession = vi.fn();
+const mockLoadProfile = vi.fn();
+
+vi.mock("@/lib/services/jwt-session", () => ({
+  getJwtSession: (req: NextRequest) => mockJwtSession(req),
+}));
+
+vi.mock("@/lib/auth/profile-repo", () => ({
+  loadProfile: (id: string) => mockLoadProfile(id),
+}));
+
+process.env.MOCK_SERVICES = "true";
+
+import { GET } from "../route";
+import { resetContainer } from "@/lib/services";
+import type { Profile } from "@/lib/auth/profile-repo";
+
+const coach: Profile = {
+  userId: "c1",
+  email: "coach@example.com",
+  phone: null,
+  name: "Coach",
+  role: "coach",
+  status: "active",
+  hasIntro: false,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const req = () =>
+  new NextRequest("http://localhost/api/admin/change-requests", {
+    headers: { authorization: "Bearer jwt" },
+  });
+
+describe("GET /api/admin/change-requests", () => {
+  beforeEach(() => {
+    resetContainer();
+    mockJwtSession.mockResolvedValue({ userId: "c1", email: "coach@example.com" });
+    mockLoadProfile.mockResolvedValue(coach);
+  });
+
+  afterEach(() => {
+    mockJwtSession.mockReset();
+    mockLoadProfile.mockReset();
+  });
+
+  it("returns empty list when nothing pending", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.requests).toEqual([]);
+  });
+
+  it("returns 403 for non-coach", async () => {
+    mockLoadProfile.mockResolvedValue({ ...coach, role: "trainee" });
+    const res = await GET(req());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 without JWT", async () => {
+    mockJwtSession.mockResolvedValue(null);
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/admin/change-requests/route.ts
+++ b/src/app/api/admin/change-requests/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getContainer } from "@/lib/services";
+import { requireCoach } from "@/lib/auth/require";
+
+/** Pending change-requests for the coach to decide on. */
+export async function GET(request: NextRequest) {
+  const r = await requireCoach(request);
+  if ("error" in r) return r.error;
+
+  const { coachRead } = getContainer();
+  const requests = await coachRead.getPendingChangeRequests();
+  return NextResponse.json({ requests });
+}

--- a/src/app/api/admin/dashboard/__tests__/route.test.ts
+++ b/src/app/api/admin/dashboard/__tests__/route.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockJwtSession = vi.fn();
+const mockLoadProfile = vi.fn();
+
+vi.mock("@/lib/services/jwt-session", () => ({
+  getJwtSession: (req: NextRequest) => mockJwtSession(req),
+}));
+
+vi.mock("@/lib/auth/profile-repo", () => ({
+  loadProfile: (id: string) => mockLoadProfile(id),
+}));
+
+process.env.MOCK_SERVICES = "true";
+
+import { GET } from "../route";
+import { resetContainer } from "@/lib/services";
+import type { Profile } from "@/lib/auth/profile-repo";
+
+const coach: Profile = {
+  userId: "c1",
+  email: "coach@example.com",
+  phone: null,
+  name: "Coach",
+  role: "coach",
+  status: "active",
+  hasIntro: false,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const req = () =>
+  new NextRequest("http://localhost/api/admin/dashboard", {
+    headers: { authorization: "Bearer jwt" },
+  });
+
+describe("GET /api/admin/dashboard", () => {
+  beforeEach(() => {
+    resetContainer();
+    mockJwtSession.mockResolvedValue({ userId: "c1", email: "coach@example.com" });
+    mockLoadProfile.mockResolvedValue(coach);
+  });
+
+  afterEach(() => {
+    mockJwtSession.mockReset();
+    mockLoadProfile.mockReset();
+  });
+
+  it("returns DashboardView shape", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveProperty("pendingApprovals");
+    expect(body).toHaveProperty("pendingChangeRequests");
+    expect(body).toHaveProperty("noShowsThisWeek");
+    expect(body).toHaveProperty("todayRoster");
+    expect(body).toHaveProperty("urgentRequests");
+    expect(Array.isArray(body.todayRoster)).toBe(true);
+    expect(Array.isArray(body.urgentRequests)).toBe(true);
+  });
+
+  it("returns 403 for non-coach", async () => {
+    mockLoadProfile.mockResolvedValue({ ...coach, role: "trainee" });
+    const res = await GET(req());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 without JWT", async () => {
+    mockJwtSession.mockResolvedValue(null);
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/admin/dashboard/route.ts
+++ b/src/app/api/admin/dashboard/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getContainer } from "@/lib/services";
+import { requireCoach } from "@/lib/auth/require";
+
+/** Coach dashboard view: pending counts + today's roster + urgent requests. */
+export async function GET(request: NextRequest) {
+  const r = await requireCoach(request);
+  if ("error" in r) return r.error;
+
+  const { coachRead } = getContainer();
+  const dashboard = await coachRead.getCoachDashboard();
+  return NextResponse.json(dashboard);
+}

--- a/src/app/api/admin/trainees/[id]/__tests__/detail.test.ts
+++ b/src/app/api/admin/trainees/[id]/__tests__/detail.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockJwtSession = vi.fn();
+const mockLoadProfile = vi.fn();
+const mockGetTraineeProfile = vi.fn();
+
+vi.mock("@/lib/services/jwt-session", () => ({
+  getJwtSession: (req: NextRequest) => mockJwtSession(req),
+}));
+
+vi.mock("@/lib/auth/profile-repo", () => ({
+  loadProfile: (id: string) => mockLoadProfile(id),
+}));
+
+vi.mock("@/lib/services/trainee-profile-repo", () => ({
+  getTraineeProfile: (id: string) => mockGetTraineeProfile(id),
+}));
+
+process.env.MOCK_SERVICES = "true";
+
+import { GET } from "../route";
+import { getContainer, resetContainer, getAuthService } from "@/lib/services";
+import { MockAuthService } from "@/lib/supabase/auth-service";
+import type { Profile } from "@/lib/auth/profile-repo";
+import type { Profile as DomainProfile } from "@/lib/types";
+
+const coach: Profile = {
+  userId: "c1",
+  email: "coach@example.com",
+  phone: null,
+  name: "Coach",
+  role: "coach",
+  status: "active",
+  hasIntro: false,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const req = () =>
+  new NextRequest("http://localhost/api/admin/trainees/t1", {
+    headers: { authorization: "Bearer jwt" },
+  });
+
+const params = { params: Promise.resolve({ id: "t1" }) };
+
+describe("GET /api/admin/trainees/[id]", () => {
+  beforeEach(() => {
+    resetContainer();
+    mockJwtSession.mockResolvedValue({ userId: "c1", email: "coach@example.com" });
+    mockLoadProfile.mockResolvedValue(coach);
+    mockGetTraineeProfile.mockResolvedValue({
+      phone: "+972501234567",
+      introText: "Hi, I want to train",
+      photoUrl: null,
+      dateOfBirth: "1992-04-08",
+      heightCm: 168,
+      weightKg: 65,
+      goals: "build strength",
+      medical: "none",
+    });
+
+    const auth = getAuthService() as MockAuthService;
+    auth._seedTrainee({
+      id: "t1",
+      name: "Yael",
+      role: "trainee",
+      isRecurring: false,
+      preferredDay: null,
+      preferredTime: null,
+      isActive: true,
+      createdAt: new Date("2026-01-01"),
+    } as DomainProfile);
+  });
+
+  afterEach(() => {
+    mockJwtSession.mockReset();
+    mockLoadProfile.mockReset();
+    mockGetTraineeProfile.mockReset();
+  });
+
+  it("includes the trainee profile bio fields", async () => {
+    const res = await GET(req(), params);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.profile).toBeDefined();
+    expect(body.profile.dateOfBirth).toBe("1992-04-08");
+    expect(body.profile.heightCm).toBe(168);
+    expect(body.profile.weightKg).toBe(65);
+    expect(body.profile.goals).toBe("build strength");
+    expect(body.profile.medical).toBe("none");
+    expect(body.profile.phone).toBe("+972501234567");
+  });
+
+  it("returns 404 when trainee unknown", async () => {
+    const res = await GET(req(), { params: Promise.resolve({ id: "ghost" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when caller is not a coach", async () => {
+    mockLoadProfile.mockResolvedValue({ ...coach, role: "trainee" });
+    const res = await GET(req(), params);
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/admin/trainees/[id]/route.ts
+++ b/src/app/api/admin/trainees/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getContainer } from "@/lib/services";
 import { requireCoach } from "@/lib/auth/require";
+import { getTraineeProfile } from "@/lib/services/trainee-profile-repo";
 
 export async function GET(
   request: NextRequest,
@@ -17,7 +18,8 @@ export async function GET(
     return NextResponse.json({ error: "Trainee not found" }, { status: 404 });
   }
 
-  // Map to the existing response shape for mobile compatibility.
+  const profile = await getTraineeProfile(id);
+
   return NextResponse.json({
     trainee: {
       id: detail.trainee.id,
@@ -29,6 +31,7 @@ export async function GET(
         detail.trainee.status !== "deactivated" &&
         detail.trainee.status !== "rejected",
     },
+    profile,
     sessions: detail.recentBookings.map((e) => ({
       bookingId: e.bookingId,
       slotId: e.slotId,

--- a/src/app/api/coach-settings/__tests__/route.test.ts
+++ b/src/app/api/coach-settings/__tests__/route.test.ts
@@ -3,7 +3,7 @@ import { NextRequest } from "next/server";
 
 const mockJwtSession = vi.fn();
 const mockLoadProfile = vi.fn();
-const mockUpdateContactPhone = vi.fn();
+const mockUpdateCoachInfo = vi.fn();
 
 vi.mock("@/lib/services/jwt-session", () => ({
   getJwtSession: (req: NextRequest) => mockJwtSession(req),
@@ -15,8 +15,8 @@ vi.mock("@/lib/auth/profile-repo", () => ({
 
 vi.mock("@/lib/services/coach-info-repo", () => ({
   getCoachInfo: vi.fn(),
-  updateCoachContactPhone: (coachId: string, phone: string) =>
-    mockUpdateContactPhone(coachId, phone),
+  updateCoachInfo: (coachId: string, patch: unknown) =>
+    mockUpdateCoachInfo(coachId, patch),
 }));
 
 import { PATCH } from "../route";
@@ -35,7 +35,7 @@ describe("PATCH /api/coach-settings", () => {
   afterEach(() => {
     mockJwtSession.mockReset();
     mockLoadProfile.mockReset();
-    mockUpdateContactPhone.mockReset();
+    mockUpdateCoachInfo.mockReset();
   });
 
   it("returns 401 without JWT", async () => {
@@ -58,7 +58,7 @@ describe("PATCH /api/coach-settings", () => {
     });
     const res = await PATCH(makeRequest({ contactPhone: "+972501234567" }, "Bearer jwt"));
     expect(res.status).toBe(403);
-    expect(mockUpdateContactPhone).not.toHaveBeenCalled();
+    expect(mockUpdateCoachInfo).not.toHaveBeenCalled();
   });
 
   it("returns 400 for non-E.164 phone", async () => {
@@ -89,10 +89,46 @@ describe("PATCH /api/coach-settings", () => {
       hasIntro: false,
       createdAt: "2026-01-01T00:00:00Z",
     });
-    mockUpdateContactPhone.mockResolvedValue(undefined);
+    mockUpdateCoachInfo.mockResolvedValue(undefined);
 
     const res = await PATCH(makeRequest({ contactPhone: "+972501234567" }, "Bearer jwt"));
     expect(res.status).toBe(200);
-    expect(mockUpdateContactPhone).toHaveBeenCalledWith("c1", "+972501234567");
+    expect(mockUpdateCoachInfo).toHaveBeenCalledWith("c1", { contactPhone: "+972501234567" });
+  });
+
+  it("updates bio + specialty + yearsExperience", async () => {
+    mockJwtSession.mockResolvedValue({ userId: "c1", email: "coach@example.com" });
+    mockLoadProfile.mockResolvedValue({
+      userId: "c1",
+      email: "coach@example.com",
+      phone: null,
+      name: "Coach",
+      role: "coach",
+      status: "active",
+      hasIntro: false,
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    mockUpdateCoachInfo.mockResolvedValue(undefined);
+
+    const body = { bio: "מאמן כושר", specialty: "כוח", yearsExperience: 8 };
+    const res = await PATCH(makeRequest(body, "Bearer jwt"));
+    expect(res.status).toBe(200);
+    expect(mockUpdateCoachInfo).toHaveBeenCalledWith("c1", body);
+  });
+
+  it("rejects out-of-range yearsExperience", async () => {
+    mockJwtSession.mockResolvedValue({ userId: "c1", email: "coach@example.com" });
+    mockLoadProfile.mockResolvedValue({
+      userId: "c1",
+      email: "coach@example.com",
+      phone: null,
+      name: "Coach",
+      role: "coach",
+      status: "active",
+      hasIntro: false,
+      createdAt: "2026-01-01T00:00:00Z",
+    });
+    const res = await PATCH(makeRequest({ yearsExperience: 999 }, "Bearer jwt"));
+    expect(res.status).toBe(400);
   });
 });

--- a/src/app/api/coach-settings/route.ts
+++ b/src/app/api/coach-settings/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireCoach } from "@/lib/auth/require";
-import { updateCoachContactPhone } from "@/lib/services/coach-info-repo";
+import { updateCoachInfo, CoachInfoPatch } from "@/lib/services/coach-info-repo";
 
 const E164 = /^\+\d{8,15}$/;
 
@@ -8,14 +8,23 @@ export async function PATCH(request: NextRequest) {
   const r = await requireCoach(request);
   if ("error" in r) return r.error;
 
-  const { contactPhone } = (await request.json()) as { contactPhone?: string };
-  if (typeof contactPhone !== "string" || !E164.test(contactPhone)) {
+  const body = (await request.json()) as CoachInfoPatch;
+
+  if (body.contactPhone !== undefined && !E164.test(body.contactPhone)) {
     return NextResponse.json(
       { error: "contactPhone must be E.164 (e.g. +972501234567)" },
       { status: 400 }
     );
   }
+  if (body.yearsExperience !== undefined && body.yearsExperience !== null) {
+    if (body.yearsExperience < 0 || body.yearsExperience > 80) {
+      return NextResponse.json(
+        { error: "yearsExperience out of range (0..80)" },
+        { status: 400 }
+      );
+    }
+  }
 
-  await updateCoachContactPhone(r.coach.userId, contactPhone);
+  await updateCoachInfo(r.coach.userId, body);
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/me/dashboard/__tests__/route.test.ts
+++ b/src/app/api/me/dashboard/__tests__/route.test.ts
@@ -134,6 +134,70 @@ describe("GET /api/me/dashboard", () => {
     expect(body.recentVisibleNote.body).toBe("Great work!");
   });
 
+  it("currentStreak counts consecutive past confirmed sessions (no_show breaks it)", async () => {
+    const { store, bookings } = getContainer();
+    // Three past sessions, in chronological order: confirmed → confirmed → no_show
+    // The streak should be the trailing run = 0 (broken by no_show).
+    for (const [id, date] of [
+      ["s1", "2026-04-01"],
+      ["s2", "2026-04-03"],
+      ["s3", "2026-04-05"],
+    ] as const) {
+      store.upsertSlot({
+        id,
+        date,
+        startTime: "10:00",
+        capacity: 2,
+        lockoutOverride: false,
+        currentBookings: 0,
+      });
+    }
+    const b1 = await bookings.book("t1", "s1", { bypass: true });
+    const b2 = await bookings.book("t1", "s2", { bypass: true });
+    const b3 = await bookings.book("t1", "s3", { bypass: true });
+    if (!b1.ok || !b2.ok || !b3.ok) throw new Error("setup failed");
+    await bookings.markNoShow(b3.booking.id);
+
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.currentStreak).toBe(0);
+  });
+
+  it("currentStreak counts an uninterrupted trailing run of confirmed sessions", async () => {
+    const { store, bookings } = getContainer();
+    for (const [id, date] of [
+      ["s1", "2026-04-01"],
+      ["s2", "2026-04-03"],
+      ["s3", "2026-04-05"],
+    ] as const) {
+      store.upsertSlot({
+        id,
+        date,
+        startTime: "10:00",
+        capacity: 2,
+        lockoutOverride: false,
+        currentBookings: 0,
+      });
+    }
+    const b1 = await bookings.book("t1", "s1", { bypass: true });
+    await bookings.book("t1", "s2", { bypass: true });
+    await bookings.book("t1", "s3", { bypass: true });
+    if (!b1.ok) throw new Error("setup failed");
+    // Older session = no_show, but the two newer are confirmed → streak = 2.
+    await bookings.markNoShow(b1.booking.id);
+
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.currentStreak).toBe(2);
+  });
+
+  it("memberSinceDays uses profile.createdAt rounded to whole days", async () => {
+    // createdAt = 2026-01-01, now = 2026-04-08 → 97 days.
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.memberSinceDays).toBe(97);
+  });
+
   it("returns 403 for non-active trainee", async () => {
     mockLoadProfile.mockResolvedValue({ ...trainee, status: "pending" });
     const res = await GET(req());

--- a/src/app/api/me/dashboard/route.ts
+++ b/src/app/api/me/dashboard/route.ts
@@ -25,6 +25,9 @@ export async function GET(request: NextRequest) {
   let nextSessionAt: string | null = null;
   let nextSessionMs = Infinity;
 
+  // Collect past sessions (confirmed + no_show) for streak calculation.
+  const pastForStreak: { ms: number; status: "confirmed" | "no_show" }[] = [];
+
   for (const b of all) {
     const slot = await store.getSlot(b.slotId);
     if (!slot) continue;
@@ -37,6 +40,17 @@ export async function GET(request: NextRequest) {
       nextSessionMs = ms;
       nextSessionAt = new Date(ms).toISOString();
     }
+    if (ms < now && (b.status === "confirmed" || b.status === "no_show")) {
+      pastForStreak.push({ ms, status: b.status });
+    }
+  }
+
+  // Streak: walk past sessions newest → oldest, count confirmed until a no_show breaks the chain.
+  pastForStreak.sort((a, b) => b.ms - a.ms);
+  let currentStreak = 0;
+  for (const p of pastForStreak) {
+    if (p.status === "confirmed") currentStreak++;
+    else break;
   }
 
   const totalPast = pastConfirmed + noShows;
@@ -47,13 +61,19 @@ export async function GET(request: NextRequest) {
   const weekStart = weekStartForDate(todayStr);
   const remainingEdits = await bookings.getRemainingEdits(userId, weekStart);
 
+  const memberSinceDays = Math.floor(
+    (now - new Date(r.trainee.createdAt).getTime()) / (24 * 60 * 60 * 1000),
+  );
+
   return NextResponse.json({
     sessionsThisMonth,
     pastConfirmed,
     noShows,
     attendanceRate,
+    currentStreak,
     nextSessionAt,
     recentVisibleNote: recentVisibleNotes[0] ?? null,
     remainingEdits,
+    memberSinceDays,
   });
 }

--- a/src/app/api/me/history/__tests__/route.test.ts
+++ b/src/app/api/me/history/__tests__/route.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockJwtSession = vi.fn();
+const mockLoadProfile = vi.fn();
+
+vi.mock("@/lib/services/jwt-session", () => ({
+  getJwtSession: (req: NextRequest) => mockJwtSession(req),
+}));
+
+vi.mock("@/lib/auth/profile-repo", () => ({
+  loadProfile: (id: string) => mockLoadProfile(id),
+}));
+
+process.env.MOCK_SERVICES = "true";
+
+import { GET } from "../route";
+import { getContainer, resetContainer } from "@/lib/services";
+import type { Profile } from "@/lib/auth/profile-repo";
+
+const trainee: Profile = {
+  userId: "t1",
+  email: "t1@example.com",
+  phone: null,
+  name: "Alice",
+  role: "trainee",
+  status: "active",
+  hasIntro: true,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const req = () =>
+  new NextRequest("http://localhost/api/me/history", {
+    headers: { authorization: "Bearer jwt" },
+  });
+
+describe("GET /api/me/history", () => {
+  beforeEach(() => {
+    vi.setSystemTime(new Date("2026-04-08T06:00:00Z"));
+    resetContainer();
+    mockJwtSession.mockResolvedValue({ userId: "t1", email: "t1@example.com" });
+    mockLoadProfile.mockResolvedValue(trainee);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    mockJwtSession.mockReset();
+    mockLoadProfile.mockReset();
+  });
+
+  it("returns empty history when no bookings", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.history).toEqual([]);
+  });
+
+  it("returns all bookings (confirmed + cancelled + no_show) newest first", async () => {
+    const { store, bookings } = getContainer();
+    for (const [id, date] of [
+      ["s1", "2026-04-01"], // past
+      ["s2", "2026-04-05"], // past
+      ["s3", "2026-04-20"], // future
+    ] as const) {
+      store.upsertSlot({
+        id,
+        date,
+        startTime: "10:00",
+        capacity: 2,
+        lockoutOverride: false,
+        currentBookings: 0,
+      });
+    }
+    const b1 = await bookings.book("t1", "s1", { bypass: true });
+    const b2 = await bookings.book("t1", "s2", { bypass: true });
+    const b3 = await bookings.book("t1", "s3", { bypass: true });
+    if (!b1.ok || !b2.ok || !b3.ok) throw new Error("setup failed");
+    await bookings.markNoShow(b2.booking.id);
+    await bookings.cancel(b3.booking.id, "t1");
+
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.history).toHaveLength(3);
+    // Newest first
+    expect(body.history[0].slotId).toBe("s3");
+    expect(body.history[0].status).toBe("cancelled");
+    expect(body.history[1].slotId).toBe("s2");
+    expect(body.history[1].status).toBe("no_show");
+    expect(body.history[2].slotId).toBe("s1");
+    expect(body.history[2].status).toBe("confirmed");
+  });
+
+  it("flags isPast correctly", async () => {
+    const { store, bookings } = getContainer();
+    store.upsertSlot({
+      id: "s-past",
+      date: "2026-04-01",
+      startTime: "10:00",
+      capacity: 2,
+      lockoutOverride: false,
+      currentBookings: 0,
+    });
+    store.upsertSlot({
+      id: "s-future",
+      date: "2026-04-30",
+      startTime: "10:00",
+      capacity: 2,
+      lockoutOverride: false,
+      currentBookings: 0,
+    });
+    await bookings.book("t1", "s-past", { bypass: true });
+    await bookings.book("t1", "s-future", { bypass: true });
+
+    const res = await GET(req());
+    const body = await res.json();
+    const past = body.history.find((h: { slotId: string }) => h.slotId === "s-past");
+    const future = body.history.find((h: { slotId: string }) => h.slotId === "s-future");
+    expect(past.isPast).toBe(true);
+    expect(future.isPast).toBe(false);
+  });
+
+  it("only returns the caller's bookings", async () => {
+    const { store, bookings } = getContainer();
+    store.upsertSlot({
+      id: "s1",
+      date: "2026-04-01",
+      startTime: "10:00",
+      capacity: 2,
+      lockoutOverride: false,
+      currentBookings: 0,
+    });
+    await bookings.book("t1", "s1", { bypass: true });
+    await bookings.book("t2", "s1", { bypass: true });
+
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.history).toHaveLength(1);
+  });
+
+  it("returns 403 for non-active trainee", async () => {
+    mockLoadProfile.mockResolvedValue({ ...trainee, status: "pending" });
+    const res = await GET(req());
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/me/history/route.ts
+++ b/src/app/api/me/history/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getContainer } from "@/lib/services";
+import { requireActiveTrainee } from "@/lib/auth/require";
+import { israelSlotToUTC } from "@/lib/services/israel-time";
+
+type HistoryEntry = {
+  bookingId: string;
+  slotId: string;
+  date: string;
+  startTime: string;
+  status: "confirmed" | "cancelled" | "no_show";
+  startsAt: string; // ISO
+  isPast: boolean;
+};
+
+/** Full history for the active trainee — confirmed, cancelled, no_show — newest first. */
+export async function GET(request: NextRequest) {
+  const r = await requireActiveTrainee(request);
+  if ("error" in r) return r.error;
+
+  const { store } = getContainer();
+  const all = await store.getAllBookings();
+  const mine = all.filter((b) => b.traineeId === r.trainee.userId);
+
+  const now = Date.now();
+  const entries: HistoryEntry[] = [];
+  for (const b of mine) {
+    const slot = await store.getSlot(b.slotId);
+    if (!slot) continue;
+    const startsAtMs = israelSlotToUTC(slot.date, slot.startTime).getTime();
+    entries.push({
+      bookingId: b.id,
+      slotId: b.slotId,
+      date: slot.date,
+      startTime: slot.startTime,
+      status: b.status as HistoryEntry["status"],
+      startsAt: new Date(startsAtMs).toISOString(),
+      isPast: startsAtMs < now,
+    });
+  }
+  entries.sort((a, b) => new Date(b.startsAt).getTime() - new Date(a.startsAt).getTime());
+
+  return NextResponse.json({ history: entries });
+}

--- a/src/lib/services/coach-info-repo.ts
+++ b/src/lib/services/coach-info-repo.ts
@@ -3,6 +3,16 @@ import { createClient } from "@supabase/supabase-js";
 export type CoachInfo = {
   name: string;
   contactPhone: string | null;
+  bio: string | null;
+  specialty: string | null;
+  yearsExperience: number | null;
+};
+
+export type CoachInfoPatch = {
+  contactPhone?: string;
+  bio?: string | null;
+  specialty?: string | null;
+  yearsExperience?: number | null;
 };
 
 function admin() {
@@ -25,13 +35,16 @@ export async function getCoachInfo(): Promise<CoachInfo | null> {
 
   const { data: settings } = await db
     .from("coach_settings")
-    .select("contact_phone")
+    .select("contact_phone, bio, specialty, years_experience")
     .limit(1)
     .maybeSingle();
 
   return {
     name: coach.name as string,
     contactPhone: (settings?.contact_phone as string | null) ?? null,
+    bio: (settings?.bio as string | null) ?? null,
+    specialty: (settings?.specialty as string | null) ?? null,
+    yearsExperience: (settings?.years_experience as number | null) ?? null,
   };
 }
 
@@ -42,4 +55,18 @@ export async function updateCoachContactPhone(coachId: string, phone: string): P
     .from("coach_settings")
     .upsert({ id: coachId, contact_phone: phone }, { onConflict: "id" });
   if (error) throw new Error(`updateCoachContactPhone failed: ${error.message}`);
+}
+
+export async function updateCoachInfo(coachId: string, patch: CoachInfoPatch): Promise<void> {
+  const db = admin();
+  const dbPatch: Record<string, unknown> = { id: coachId };
+  if (patch.contactPhone !== undefined) dbPatch.contact_phone = patch.contactPhone;
+  if (patch.bio !== undefined) dbPatch.bio = patch.bio;
+  if (patch.specialty !== undefined) dbPatch.specialty = patch.specialty;
+  if (patch.yearsExperience !== undefined) dbPatch.years_experience = patch.yearsExperience;
+
+  const { error } = await db
+    .from("coach_settings")
+    .upsert(dbPatch, { onConflict: "id" });
+  if (error) throw new Error(`updateCoachInfo failed: ${error.message}`);
 }

--- a/supabase/migrations/00015_coach_bio.sql
+++ b/supabase/migrations/00015_coach_bio.sql
@@ -1,0 +1,7 @@
+-- Coach bio / specialty / years_experience columns on coach_settings.
+-- Used by the trainee-side Contact Coach card and the coach's own profile UI.
+
+alter table coach_settings
+  add column if not exists bio text,
+  add column if not exists specialty text,
+  add column if not exists years_experience smallint;


### PR DESCRIPTION
## Summary

Four vertical slices on top of master enriching trainee + coach profile/dashboard UX. All TDD'd.

- **Trainee profile editor** — `/api/me/profile` PATCH + new mobile editor (dob/height/weight/goals/medical/phone) with inline validation; ProfileScreen redesigned with avatar card + role-specific body.
- **Streak + member-since** — `/api/me/dashboard` returns currentStreak (trailing run of past confirmed, broken by no_show) and memberSinceDays. Trainee hero gains 🔥 streak badge + "חבר/ה כבר X חודשים" subtitle + separate next-session pill.
- **Coach dashboard quick-stats** — new `/api/admin/dashboard` GET exposes CoachReadModel.getCoachDashboard(); coach week screen gains second stat row (בקשות שינוי, אי-הגעה השבוע).
- **Trainee history screen** — `/api/me/history` returns full history newest-first; new HistoryScreen month-grouped with Hebrew month names + status labels. Quick-action chip now navigates instead of placeholder snackbar.

## Test plan
- [x] Backend vitest: +14 new tests, all green (245/247; 2 pre-existing slot-availability failures unrelated)
- [x] Mobile flutter test: 74/74 green
- [x] `tsc --noEmit` clean; `flutter analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)