### PR TITLE
fix: reschedule approval books new slot before cancelling old (#55)

### DIFF
--- a/docs/adr/0007-reschedule-approval-books-new-before-cancelling-old.md
+++ b/docs/adr/0007-reschedule-approval-books-new-before-cancelling-old.md
@@ -1,0 +1,18 @@
+# Reschedule approval books the new slot before cancelling the old one
+
+When a coach approves a reschedule request, the new booking is created **before** the old booking is cancelled. If the target slot has filled since the request was submitted (race), approval fails with `SLOT_FULL`; the request stays `pending`, the old booking is preserved, and the coach gets a clear error.
+
+Previously: old booking was cancelled first, then `this.book(...)` was called on the new slot. If `book` returned `SLOT_FULL` (race), the result was silently discarded — request stamped `approved`, trainee left with nothing. Surfaced as #55.
+
+## Considered options
+
+- **Hold target slot capacity at request submit time** — rejected. Mirrors the way the OLD slot is held during a cancel request, but doubles the held capacity per pending reschedule and adds a release path on reject/expire. Schema and behaviour changes across `requestReschedule`, `decideRequest`, and the expiry path. Disproportionate for a low-frequency race.
+- **Book-new-before-cancel-old** — chosen. One reordering inside `decideRequest`, no schema change. The window for any further race shrinks to a single `book(..., bypass: true)` call against the in-memory store; if it loses, `SLOT_FULL` propagates up and the coach sees the conflict.
+- **Auto-reject the request with a `reason: "target_full"` decision note** — rejected. Coach often wants to discuss alternatives with the trainee; auto-reject forces a re-request round trip when a "try again with a different target" UX is cheaper.
+
+## Consequences
+
+- Coach receives `SLOT_FULL` (HTTP 409) when approving a reschedule whose target has filled. The request stays `pending` so the coach can re-decide (likely after texting the trainee an alternative).
+- For the brief window between `book()` succeeding and the old `updateBooking({ ..., status: "cancelled" })` completing, the trainee holds confirmed bookings on **both** slots. This is acceptable: `bypass: true` skips the weekly cap, no domain rule forbids transient double-holding across distinct slots, and the second step almost always succeeds (in-process store update).
+- If `deleteCalendarEvent` or `updateBooking` fails after the new booking has been written, we land in an ugly state: trainee has two confirmed bookings. Same hazard as the existing `reschedule()` method (lines 273-347) — not introduced by this change. Tracked implicitly under #55's follow-up.
+- `decideRequest` no longer returns `{ ok: true, effectedBooking: undefined }`: every successful approval now produces an `effectedBooking` for reschedule decisions. Callers relying on the `undefined` branch will get an error result instead.

--- a/src/lib/__tests__/bookings-requests.test.ts
+++ b/src/lib/__tests__/bookings-requests.test.ts
@@ -142,7 +142,7 @@ describe("Bookings — request/decide (Phase 15)", () => {
   });
 
   describe("decideRequest — approve (reschedule) race conditions", () => {
-    it("when target slot has since filled up, request is approved but no new booking is made (trainee loses both)", async () => {
+    it("when target slot has since filled up, approval is rejected with SLOT_FULL and old booking is preserved (#55)", async () => {
       // Trainee requests reschedule slot-mon → slot-tue
       const booking = await setupBooking();
       const reqRes = await bookings.requestReschedule(
@@ -158,21 +158,17 @@ describe("Bookings — request/decide (Phase 15)", () => {
       await bookings.book("t3", "slot-tue");
       expect(store.getSlot("slot-tue")!.currentBookings).toBe(2);
 
-      // Coach approves the reschedule request anyway
+      // Coach approves anyway — should fail loudly, leaving trainee + request intact.
       const decision = await bookings.decideRequest(reqRes.request.id, "c1", "approve");
 
-      // Documents current behaviour: request approved, old booking cancelled,
-      // new booking NOT made (silently). Trainee ends up with no booking.
-      // (This is a latent bug — file a follow-up issue if surprising; the
-      // test locks in current behaviour so the regression is visible.)
-      expect(decision.ok).toBe(true);
-      if (decision.ok) {
-        expect(decision.request.status).toBe("approved");
-        expect(decision.effectedBooking).toBeUndefined();
-      }
-      expect(store.getBooking(booking.id)!.status).toBe("cancelled");
-      expect(store.getSlot("slot-mon")!.currentBookings).toBe(0);
-      // slot-tue is still full with t2 + t3 (not t1)
+      expect(decision).toMatchObject({ ok: false, error: "SLOT_FULL" });
+      // Request stays pending so coach can re-decide once trainee picks a new target
+      const fresh = await store.getChangeRequest(reqRes.request.id);
+      expect(fresh!.status).toBe("pending");
+      // Old booking preserved
+      expect(store.getBooking(booking.id)!.status).toBe("confirmed");
+      expect(store.getSlot("slot-mon")!.currentBookings).toBe(1);
+      // slot-tue untouched
       expect(store.getSlot("slot-tue")!.currentBookings).toBe(2);
     });
   });

--- a/src/lib/services/bookings.ts
+++ b/src/lib/services/bookings.ts
@@ -434,22 +434,25 @@ export function makeBookings(
       const oldSlot = await store.getSlot(booking.slotId);
       if (!oldSlot) return { ok: false, error: "NOT_FOUND", message: "Slot not found" };
 
+      // For reschedule: book the NEW slot first, before touching the old one.
+      // If target filled since request was submitted (race), bail with SLOT_FULL —
+      // leaves request pending + old booking intact (#55).
+      let effectedBooking: Booking | undefined;
+      if (request.requestedNewSlotId) {
+        const r = await this.book(booking.traineeId, request.requestedNewSlotId, {
+          bypass: true,
+          isAutoBooked: booking.isAutoBooked,
+        });
+        if (!r.ok) return { ok: false, error: r.error, message: r.message };
+        effectedBooking = r.booking;
+      }
+
       await deleteCalendarEvent(booking.googleEventId);
       await store.updateBooking({ ...booking, status: "cancelled" });
       await store.updateSlot({
         ...oldSlot,
         currentBookings: Math.max(0, oldSlot.currentBookings - 1),
       });
-
-      let effectedBooking: Booking | undefined;
-      if (request.requestedNewSlotId) {
-        // Reschedule — book the new slot under the coach's authority (bypass limits).
-        const r = await this.book(booking.traineeId, request.requestedNewSlotId, {
-          bypass: true,
-          isAutoBooked: booking.isAutoBooked,
-        });
-        if (r.ok) effectedBooking = r.booking;
-      }
 
       await store.updateChangeRequest(requestId, {
         status: statusValue,


### PR DESCRIPTION
## Summary

- Reorders `Bookings.decideRequest(... 'approve')` so reschedule books the new slot **before** cancelling the old one. If the target has filled since the request was submitted (race), approval bails with `SLOT_FULL`; old booking + request stay intact so the coach can re-decide.
- ADR-0007 captures the choice (book-new-first vs holding capacity at request time vs auto-reject).
- Closes #55.

## Test plan
- [x] Backend: `npx vitest run` → 265/265
- [x] TypeScript: `npx tsc --noEmit` clean
- [x] Lint: `npx eslint src --ext .ts,.tsx` clean
- [x] Mobile: `flutter test` → 109/109
- [x] Race test (`bookings-requests.test.ts` → "decideRequest — approve (reschedule) race conditions") updated from current-behaviour lock-in to expect `SLOT_FULL` + preserved old booking + still-pending request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)