### PR TITLE
feat: reminder cadence retune — 24h + 2h + post-session (#53)

### DIFF
--- a/src/app/api/cron/send-reminders/__tests__/route.test.ts
+++ b/src/app/api/cron/send-reminders/__tests__/route.test.ts
@@ -30,9 +30,9 @@ describe("GET /api/cron/send-reminders", () => {
   it("sends reminders for due bookings", async () => {
     const slotDate = "2026-05-22";
     const slotTime = "10:00";
-    // freeze clock 62 min before the slot
+    // freeze clock 120 min before the slot — inside the 2h-before window
     vi.setSystemTime(
-      new Date(israelSlotToUTC(slotDate, slotTime).getTime() - 62 * 60 * 1000)
+      new Date(israelSlotToUTC(slotDate, slotTime).getTime() - 120 * 60 * 1000)
     );
 
     const { store } = getContainer();
@@ -52,7 +52,9 @@ describe("GET /api/cron/send-reminders", () => {
       isAutoBooked: false,
       status: "confirmed",
       createdAt: new Date(),
-      reminderSentAt: null,
+      reminder24hSentAt: null,
+      reminder2hSentAt: null,
+      postSessionPromptSentAt: null,
     });
 
     const res = await GET(
@@ -61,8 +63,9 @@ describe("GET /api/cron/send-reminders", () => {
 
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json.sent).toBe(1);
+    expect(json.sent.reminder_2h).toBe(1);
     const notifier = getNotificationService() as MockNotificationService;
     expect(notifier.sentToTrainee).toHaveLength(1);
+    expect(notifier.sentToTrainee[0].kind).toBe("reminder_2h");
   });
 });

--- a/src/lib/__tests__/reminders.test.ts
+++ b/src/lib/__tests__/reminders.test.ts
@@ -3,159 +3,205 @@ import { MockBookingStore } from "@/lib/services/booking-store";
 import { MockNotificationService } from "@/lib/services/notification";
 import { sendDueReminders } from "@/lib/services/reminders";
 import { israelSlotToUTC } from "@/lib/services/israel-time";
+import type { ReminderKind } from "@/lib/types";
 
-describe("sendDueReminders", () => {
-  let store: MockBookingStore;
-  let notifier: MockNotificationService;
-  const slotDate = "2026-05-22";
-  const slotTime = "10:00";
-  // 10:00 Asia/Jerusalem on the slot day, minus 62 minutes → inside [60,65) window
-  const now = new Date(
-    israelSlotToUTC(slotDate, slotTime).getTime() - 62 * 60 * 1000
-  );
+const slotDate = "2026-05-22";
+const slotTime = "10:00";
+const slotStart = israelSlotToUTC(slotDate, slotTime);
 
-  function seedConfirmed(id: string, reminderSentAt: Date | null = null) {
+function seedConfirmed(
+  store: MockBookingStore,
+  id: string,
+  flags: Partial<{
+    reminder24hSentAt: Date | null;
+    reminder2hSentAt: Date | null;
+    postSessionPromptSentAt: Date | null;
+  }> = {}
+) {
+  const slotId = `slot-${slotDate}-${slotTime}`;
+  if (!store.getSlot(slotId)) {
     store.addSlot({
-      id: `slot-${slotDate}-${slotTime}`,
+      id: slotId,
       date: slotDate,
       startTime: slotTime,
       capacity: 2,
       lockoutOverride: false,
       currentBookings: 1,
     });
-    store.addBooking({
-      id,
-      slotId: `slot-${slotDate}-${slotTime}`,
-      traineeId: "t1",
-      googleEventId: null,
-      isAutoBooked: false,
-      status: "confirmed",
-      createdAt: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000),
-      reminderSentAt,
-    });
   }
+  store.addBooking({
+    id,
+    slotId,
+    traineeId: "t1",
+    googleEventId: null,
+    isAutoBooked: false,
+    status: "confirmed",
+    createdAt: new Date(slotStart.getTime() - 86_400_000),
+    reminder24hSentAt: null,
+    reminder2hSentAt: null,
+    postSessionPromptSentAt: null,
+    ...flags,
+  });
+}
+
+describe("sendDueReminders — three-window cadence (#53)", () => {
+  let store: MockBookingStore;
+  let notifier: MockNotificationService;
 
   beforeEach(() => {
     store = new MockBookingStore();
     notifier = new MockNotificationService();
   });
 
-  it("notifies trainee and stamps reminder_sent_at for bookings in the window", async () => {
-    seedConfirmed("b1");
+  function setNow(offsetMinFromSlotStart: number): Date {
+    return new Date(slotStart.getTime() + offsetMinFromSlotStart * 60 * 1000);
+  }
 
-    const result = await sendDueReminders(store, notifier, now);
-
-    expect(notifier.sentToTrainee).toHaveLength(1);
-    expect(notifier.sentToTrainee[0]).toMatchObject({
-      traineeId: "t1",
-      slotDate,
-      slotTime,
+  describe("24h-before window", () => {
+    it("fires once when slot is ~24h away", async () => {
+      seedConfirmed(store, "b1");
+      const result = await sendDueReminders(store, notifier, setNow(-24 * 60));
+      expect(result.sent.reminder_24h).toBe(1);
+      expect(notifier.sentToTrainee[0]).toMatchObject({ kind: "reminder_24h", traineeId: "t1" });
+      expect(store.getBooking("b1")!.reminder24hSentAt).toBeInstanceOf(Date);
     });
-    expect(result.sent).toBe(1);
-    expect(store.getBooking("b1")!.reminderSentAt).toBeInstanceOf(Date);
-  });
 
-  it("skips bookings already stamped with reminder_sent_at", async () => {
-    seedConfirmed("b1", new Date(now.getTime() - 5 * 60 * 1000));
-
-    const result = await sendDueReminders(store, notifier, now);
-
-    expect(notifier.sentToTrainee).toHaveLength(0);
-    expect(result.sent).toBe(0);
-  });
-
-  it("skips cancelled bookings", async () => {
-    seedConfirmed("b1");
-    const b = store.getBooking("b1")!;
-    store.updateBooking({ ...b, status: "cancelled" });
-
-    const result = await sendDueReminders(store, notifier, now);
-
-    expect(notifier.sentToTrainee).toHaveLength(0);
-    expect(result.sent).toBe(0);
-  });
-
-  it("skips bookings outside the window (too soon — slot 30 min away)", async () => {
-    seedConfirmed("b1");
-    const earlyNow = new Date(
-      israelSlotToUTC(slotDate, slotTime).getTime() - 30 * 60 * 1000
-    );
-
-    const result = await sendDueReminders(store, notifier, earlyNow);
-
-    expect(notifier.sentToTrainee).toHaveLength(0);
-    expect(result.sent).toBe(0);
-  });
-
-  it("skips bookings outside the window (too far — slot 90 min away)", async () => {
-    seedConfirmed("b1");
-    const farNow = new Date(
-      israelSlotToUTC(slotDate, slotTime).getTime() - 90 * 60 * 1000
-    );
-
-    const result = await sendDueReminders(store, notifier, farNow);
-
-    expect(notifier.sentToTrainee).toHaveLength(0);
-    expect(result.sent).toBe(0);
-  });
-
-  it("includes slot at exactly 60 min away (window start inclusive)", async () => {
-    seedConfirmed("b1");
-    const exactly60 = new Date(
-      israelSlotToUTC(slotDate, slotTime).getTime() - 60 * 60 * 1000
-    );
-
-    const result = await sendDueReminders(store, notifier, exactly60);
-
-    expect(result.sent).toBe(1);
-  });
-
-  it("excludes slot at exactly 65 min away (window end exclusive)", async () => {
-    seedConfirmed("b1");
-    const exactly65 = new Date(
-      israelSlotToUTC(slotDate, slotTime).getTime() - 65 * 60 * 1000
-    );
-
-    const result = await sendDueReminders(store, notifier, exactly65);
-
-    expect(result.sent).toBe(0);
-  });
-
-  it("processes multiple due bookings in the same run", async () => {
-    store.addSlot({
-      id: `slot-${slotDate}-${slotTime}`,
-      date: slotDate,
-      startTime: slotTime,
-      capacity: 2,
-      lockoutOverride: false,
-      currentBookings: 2,
+    it("inclusive at exact lower edge (-23h55m)", async () => {
+      seedConfirmed(store, "b1");
+      const result = await sendDueReminders(store, notifier, setNow(-(24 * 60 - 5)));
+      expect(result.sent.reminder_24h).toBe(1);
     });
-    for (const tid of ["t1", "t2"]) {
-      store.addBooking({
-        id: `b-${tid}`,
-        slotId: `slot-${slotDate}-${slotTime}`,
-        traineeId: tid,
-        googleEventId: null,
-        isAutoBooked: false,
-        status: "confirmed",
-        createdAt: new Date(now.getTime() - 86_400_000),
-        reminderSentAt: null,
+
+    it("exclusive at exact upper edge (-24h05m)", async () => {
+      seedConfirmed(store, "b1");
+      const result = await sendDueReminders(store, notifier, setNow(-(24 * 60 + 5)));
+      expect(result.sent.reminder_24h).toBe(0);
+    });
+
+    it("excludes when too far away (-24h10m)", async () => {
+      seedConfirmed(store, "b1");
+      const result = await sendDueReminders(store, notifier, setNow(-24 * 60 - 10));
+      expect(result.sent.reminder_24h).toBe(0);
+    });
+
+    it("does not double-fire across cron runs", async () => {
+      seedConfirmed(store, "b1");
+      await sendDueReminders(store, notifier, setNow(-24 * 60));
+      const second = await sendDueReminders(store, notifier, setNow(-24 * 60));
+      expect(second.sent.reminder_24h).toBe(0);
+      expect(notifier.sentToTrainee).toHaveLength(1);
+    });
+  });
+
+  describe("2h-before window", () => {
+    it("fires once when slot is ~2h away", async () => {
+      seedConfirmed(store, "b1");
+      const result = await sendDueReminders(store, notifier, setNow(-2 * 60));
+      expect(result.sent.reminder_2h).toBe(1);
+      expect(notifier.sentToTrainee[0].kind).toBe("reminder_2h");
+      expect(store.getBooking("b1")!.reminder2hSentAt).toBeInstanceOf(Date);
+    });
+
+    it("does not fire 24h push during 2h window", async () => {
+      seedConfirmed(store, "b1");
+      const result = await sendDueReminders(store, notifier, setNow(-2 * 60));
+      expect(result.sent.reminder_24h).toBe(0);
+      expect(store.getBooking("b1")!.reminder24hSentAt).toBeNull();
+    });
+
+    it("idempotent on repeat run", async () => {
+      seedConfirmed(store, "b1");
+      await sendDueReminders(store, notifier, setNow(-2 * 60));
+      const second = await sendDueReminders(store, notifier, setNow(-2 * 60));
+      expect(second.sent.reminder_2h).toBe(0);
+    });
+  });
+
+  describe("post-session window (30min after slot END)", () => {
+    // Slot is 60 min. End = slotStart + 60. Window targets end+30 ⇒ slotStart+90.
+    it("fires when slot ended ~30min ago (slotStart+90m)", async () => {
+      seedConfirmed(store, "b1");
+      const result = await sendDueReminders(store, notifier, setNow(90));
+      expect(result.sent.post_session).toBe(1);
+      expect(notifier.sentToTrainee[0].kind).toBe("post_session");
+      expect(store.getBooking("b1")!.postSessionPromptSentAt).toBeInstanceOf(Date);
+    });
+
+    it("does not fire pre-session", async () => {
+      seedConfirmed(store, "b1");
+      const result = await sendDueReminders(store, notifier, setNow(-5));
+      expect(result.sent.post_session).toBe(0);
+    });
+
+    it("idempotent on repeat run", async () => {
+      seedConfirmed(store, "b1");
+      await sendDueReminders(store, notifier, setNow(90));
+      const second = await sendDueReminders(store, notifier, setNow(90));
+      expect(second.sent.post_session).toBe(0);
+    });
+  });
+
+  describe("cross-cutting", () => {
+    it("skips cancelled bookings across all kinds", async () => {
+      seedConfirmed(store, "b1");
+      const b = store.getBooking("b1")!;
+      store.updateBooking({ ...b, status: "cancelled" });
+
+      for (const off of [-24 * 60, -2 * 60, 90]) {
+        const r = await sendDueReminders(store, notifier, setNow(off));
+        expect(r.sent.reminder_24h + r.sent.reminder_2h + r.sent.post_session).toBe(0);
+      }
+    });
+
+    it("skips no_show bookings post-session (don't prompt missing sessions)", async () => {
+      seedConfirmed(store, "b1");
+      const b = store.getBooking("b1")!;
+      store.updateBooking({ ...b, status: "no_show" });
+
+      const result = await sendDueReminders(store, notifier, setNow(90));
+      expect(result.sent.post_session).toBe(0);
+    });
+
+    it("processes multiple trainees in the same run", async () => {
+      const slotId = `slot-${slotDate}-${slotTime}`;
+      store.addSlot({
+        id: slotId,
+        date: slotDate,
+        startTime: slotTime,
+        capacity: 2,
+        lockoutOverride: false,
+        currentBookings: 2,
       });
-    }
+      for (const tid of ["t1", "t2"]) {
+        store.addBooking({
+          id: `b-${tid}`,
+          slotId,
+          traineeId: tid,
+          googleEventId: null,
+          isAutoBooked: false,
+          status: "confirmed",
+          createdAt: new Date(slotStart.getTime() - 86_400_000),
+          reminder24hSentAt: null,
+          reminder2hSentAt: null,
+          postSessionPromptSentAt: null,
+        });
+      }
+      const result = await sendDueReminders(store, notifier, setNow(-24 * 60));
+      expect(result.sent.reminder_24h).toBe(2);
+    });
 
-    const result = await sendDueReminders(store, notifier, now);
+    it("kinds are independent — 24h already sent does not block 2h push", async () => {
+      seedConfirmed(store, "b1", { reminder24hSentAt: new Date(slotStart.getTime() - 24 * 60 * 60 * 1000) });
+      const result = await sendDueReminders(store, notifier, setNow(-2 * 60));
+      expect(result.sent.reminder_2h).toBe(1);
+    });
 
-    expect(result.sent).toBe(2);
-    expect(notifier.sentToTrainee).toHaveLength(2);
-  });
-
-  it("does not double-send on a repeat run (idempotent across runs)", async () => {
-    seedConfirmed("b1");
-
-    await sendDueReminders(store, notifier, now);
-    const second = await sendDueReminders(store, notifier, now);
-
-    expect(second.sent).toBe(0);
-    expect(notifier.sentToTrainee).toHaveLength(1);
+    it("Hebrew copy renders for each kind via notifyTrainee payload", async () => {
+      // sanity: payload kind round-trips through to mock service buffer
+      seedConfirmed(store, "b1");
+      await sendDueReminders(store, notifier, setNow(-24 * 60));
+      const kinds: ReminderKind[] = notifier.sentToTrainee.map((p) => p.kind);
+      expect(kinds).toEqual(["reminder_24h"]);
+    });
   });
 });

--- a/src/lib/coach/__tests__/read-model.test.ts
+++ b/src/lib/coach/__tests__/read-model.test.ts
@@ -14,7 +14,6 @@ const trainee: Profile = {
   preferredTime: null,
   isActive: true,
   createdAt: new Date("2026-01-01"),
-  reminderSentAt: null as never,
 } as Profile;
 
 describe("CoachReadModel", () => {

--- a/src/lib/services/booking-store.ts
+++ b/src/lib/services/booking-store.ts
@@ -1,4 +1,4 @@
-import { Booking, Slot, EditLog, ChangeRequest } from "@/lib/types";
+import { Booking, Slot, EditLog, ChangeRequest, ReminderKind } from "@/lib/types";
 import { israelSlotToUTC } from "./israel-time";
 
 export class BookingError extends Error {
@@ -7,6 +7,22 @@ export class BookingError extends Error {
     this.name = "BookingError";
   }
 }
+
+const REMINDER_FIELD_MAP = {
+  reminder_24h: "reminder24hSentAt",
+  reminder_2h: "reminder2hSentAt",
+  post_session: "postSessionPromptSentAt",
+} as const;
+
+export function sentFieldFor(kind: ReminderKind): keyof Booking {
+  return REMINDER_FIELD_MAP[kind];
+}
+
+export const REMINDER_DB_COLUMN: Record<ReminderKind, string> = {
+  reminder_24h: "reminder_24h_sent_at",
+  reminder_2h: "reminder_2h_sent_at",
+  post_session: "postsession_prompt_sent_at",
+};
 
 export interface BookingStore {
   getSlot(slotId: string): Promise<Slot | undefined> | Slot | undefined;
@@ -24,11 +40,17 @@ export interface BookingStore {
   getAllBookings(): Promise<Booking[]> | Booking[];
   upsertSlot(slot: Slot): Promise<void> | void;
   resetEditCount(traineeId: string, weekStart: string): Promise<void> | void;
+  /**
+   * Confirmed bookings whose slot start time lies in [windowStartUtc, windowEndUtc)
+   * and whose `<kind>_sent_at` column is still NULL. For `post_session` the window
+   * matches the slot START, not the end — caller offsets by slot duration.
+   */
   getRemindersDue(
+    kind: ReminderKind,
     windowStartUtc: Date,
     windowEndUtc: Date
   ): Promise<Array<{ booking: Booking; slot: Slot }>> | Array<{ booking: Booking; slot: Slot }>;
-  markReminderSent(bookingId: string, sentAt: Date): Promise<void> | void;
+  markReminderSent(bookingId: string, kind: ReminderKind, sentAt: Date): Promise<void> | void;
 
   // --- Phase 15: cancel-request flow ---
   createChangeRequest(input: {
@@ -143,14 +165,16 @@ export class MockBookingStore implements BookingStore {
   }
 
   getRemindersDue(
+    kind: ReminderKind,
     windowStartUtc: Date,
     windowEndUtc: Date
   ): Array<{ booking: Booking; slot: Slot }> {
     const startMs = windowStartUtc.getTime();
     const endMs = windowEndUtc.getTime();
+    const sentField = sentFieldFor(kind);
     const out: Array<{ booking: Booking; slot: Slot }> = [];
     for (const b of this.bookings.values()) {
-      if (b.status !== "confirmed" || b.reminderSentAt !== null) continue;
+      if (b.status !== "confirmed" || b[sentField] !== null) continue;
       const slot = this.slots.get(b.slotId);
       if (!slot) continue;
       const slotMs = israelSlotToUTC(slot.date, slot.startTime).getTime();
@@ -161,10 +185,10 @@ export class MockBookingStore implements BookingStore {
     return out;
   }
 
-  markReminderSent(bookingId: string, sentAt: Date): void {
+  markReminderSent(bookingId: string, kind: ReminderKind, sentAt: Date): void {
     const b = this.bookings.get(bookingId);
     if (!b) return;
-    this.bookings.set(bookingId, { ...b, reminderSentAt: sentAt });
+    this.bookings.set(bookingId, { ...b, [sentFieldFor(kind)]: sentAt });
   }
 
   createChangeRequest(input: {

--- a/src/lib/services/bookings.ts
+++ b/src/lib/services/bookings.ts
@@ -224,7 +224,9 @@ export function makeBookings(
         isAutoBooked: opts.isAutoBooked ?? false,
         status: "confirmed",
         createdAt: new Date(),
-        reminderSentAt: null,
+        reminder24hSentAt: null,
+        reminder2hSentAt: null,
+        postSessionPromptSentAt: null,
       };
 
       await store.addBooking(booking);
@@ -329,7 +331,9 @@ export function makeBookings(
         isAutoBooked: oldBooking.isAutoBooked,
         status: "confirmed",
         createdAt: new Date(),
-        reminderSentAt: null,
+        reminder24hSentAt: null,
+        reminder2hSentAt: null,
+        postSessionPromptSentAt: null,
       };
 
       await store.addBooking(newBooking);

--- a/src/lib/services/notification.ts
+++ b/src/lib/services/notification.ts
@@ -1,3 +1,5 @@
+import type { ReminderKind } from "@/lib/types";
+
 export interface NotificationPayload {
   type: "cancel" | "reschedule" | "booking";
   traineeName: string;
@@ -11,17 +13,33 @@ export interface TraineeReminderPayload {
   traineeId: string;
   slotDate: string;
   slotTime: string;
+  kind: ReminderKind;
 }
 
 export interface NotificationService {
   notifyCoach(payload: NotificationPayload): Promise<void>;
-  /** Send 1h-before reminder push to the trainee. */
+  /**
+   * Send reminder push to the trainee. Kind decides the copy:
+   *   reminder_24h → "מחר בשעה HH:MM נפגשים..."
+   *   reminder_2h  → "בעוד שעתיים אימון. נתראה!"
+   *   post_session → "איך הרגשת? תיעוד קצר עוזר..."
+   */
   notifyTrainee(payload: TraineeReminderPayload): Promise<void>;
+}
+
+const HEBREW_COPY: Record<ReminderKind, (slotTime: string) => string> = {
+  reminder_24h: (t) => `מחר בשעה ${t} נפגשים. כל עדכון, עכשיו זה הזמן.`,
+  reminder_2h: () => `בעוד שעתיים אימון. נתראה!`,
+  post_session: () => `איך הרגשת? תיעוד קצר עוזר לך לראות את ההתקדמות.`,
+};
+
+export function renderReminderCopy(payload: TraineeReminderPayload): string {
+  return HEBREW_COPY[payload.kind](payload.slotTime);
 }
 
 /**
  * Mock notification service — logs to console in dev.
- * Replace with email/push in production.
+ * Replace with FCM in production (#36).
  */
 export class MockNotificationService implements NotificationService {
   public sent: NotificationPayload[] = [];
@@ -34,6 +52,8 @@ export class MockNotificationService implements NotificationService {
 
   async notifyTrainee(payload: TraineeReminderPayload): Promise<void> {
     this.sentToTrainee.push(payload);
-    console.log(`[Notify Trainee] reminder: ${payload.traineeId} - ${payload.slotDate} ${payload.slotTime}`);
+    console.log(
+      `[Notify Trainee] ${payload.kind}: ${payload.traineeId} - ${payload.slotDate} ${payload.slotTime} — ${renderReminderCopy(payload)}`
+    );
   }
 }

--- a/src/lib/services/reminders.ts
+++ b/src/lib/services/reminders.ts
@@ -1,42 +1,68 @@
+import type { ReminderKind } from "@/lib/types";
 import { BookingStore } from "./booking-store";
 import { NotificationService } from "./notification";
 
-const WINDOW_START_MIN = 60;
-const WINDOW_END_MIN = 65;
+const SLOT_DURATION_MIN = 60;
+const WINDOW_HALF_WIDTH_MIN = 5;
+
+const TARGET_OFFSET_MIN: Record<ReminderKind, number> = {
+  // For pre-session reminders the offset is "minutes from now until slot start".
+  reminder_24h: 24 * 60,
+  reminder_2h: 2 * 60,
+  // For post-session prompt the offset is "minutes since slot END". Slots are
+  // 60 min, so 30 min after end = 90 min after start. We negate to put the
+  // window in the past (slot started 95-85 min ago).
+  post_session: -(SLOT_DURATION_MIN + 30),
+};
 
 export interface RemindersResult {
-  sent: number;
+  /** Per-kind sent counts; sum across kinds is the total push fan-out. */
+  sent: Record<ReminderKind, number>;
+  /** Total skipped due to notifier failure. */
   skipped: number;
 }
 
 /**
- * Selects confirmed bookings whose slot starts in [now+60min, now+65min),
- * pushes a 1h-before reminder to each trainee, stamps reminder_sent_at.
- * Idempotent — `reminderSentAt` filter on the store skips already-notified rows.
+ * Single cron entrypoint. Walks the three reminder windows (24h, 2h,
+ * 30min-post-session), notifies due trainees, stamps the matching column
+ * to keep it idempotent. ±5min tolerance matches the 5-min cron schedule.
  */
 export async function sendDueReminders(
   store: BookingStore,
   notifier: NotificationService,
   now: Date = new Date()
 ): Promise<RemindersResult> {
-  const windowStart = new Date(now.getTime() + WINDOW_START_MIN * 60 * 1000);
-  const windowEnd = new Date(now.getTime() + WINDOW_END_MIN * 60 * 1000);
-
-  const due = await store.getRemindersDue(windowStart, windowEnd);
-
-  let sent = 0;
+  const sent: Record<ReminderKind, number> = {
+    reminder_24h: 0,
+    reminder_2h: 0,
+    post_session: 0,
+  };
   let skipped = 0;
-  for (const { booking, slot } of due) {
-    try {
-      await notifier.notifyTrainee({
-        traineeId: booking.traineeId,
-        slotDate: slot.date,
-        slotTime: slot.startTime,
-      });
-      await store.markReminderSent(booking.id, now);
-      sent++;
-    } catch {
-      skipped++;
+
+  for (const kind of ["reminder_24h", "reminder_2h", "post_session"] as const) {
+    const targetMinutes = TARGET_OFFSET_MIN[kind];
+    const windowStart = new Date(
+      now.getTime() + (targetMinutes - WINDOW_HALF_WIDTH_MIN) * 60 * 1000
+    );
+    const windowEnd = new Date(
+      now.getTime() + (targetMinutes + WINDOW_HALF_WIDTH_MIN) * 60 * 1000
+    );
+
+    const due = await store.getRemindersDue(kind, windowStart, windowEnd);
+
+    for (const { booking, slot } of due) {
+      try {
+        await notifier.notifyTrainee({
+          traineeId: booking.traineeId,
+          slotDate: slot.date,
+          slotTime: slot.startTime,
+          kind,
+        });
+        await store.markReminderSent(booking.id, kind, now);
+        sent[kind]++;
+      } catch {
+        skipped++;
+      }
     }
   }
 

--- a/src/lib/supabase/booking-store.ts
+++ b/src/lib/supabase/booking-store.ts
@@ -1,6 +1,6 @@
 import { SupabaseClient } from "@supabase/supabase-js";
-import { Booking, Slot, EditLog, ChangeRequest } from "@/lib/types";
-import { BookingStore } from "@/lib/services/booking-store";
+import { Booking, Slot, EditLog, ChangeRequest, ReminderKind } from "@/lib/types";
+import { BookingStore, REMINDER_DB_COLUMN } from "@/lib/services/booking-store";
 import { israelSlotToUTC } from "@/lib/services/israel-time";
 
 /**
@@ -234,14 +234,16 @@ export class SupabaseBookingStore implements BookingStore {
   }
 
   async getRemindersDue(
+    kind: ReminderKind,
     windowStartUtc: Date,
     windowEndUtc: Date
   ): Promise<Array<{ booking: Booking; slot: Slot }>> {
+    const col = REMINDER_DB_COLUMN[kind];
     const { data } = await this.db
       .from("bookings")
       .select("*, slots!inner(*)")
       .eq("status", "confirmed")
-      .is("reminder_sent_at", null);
+      .is(col, null);
 
     const startMs = windowStartUtc.getTime();
     const endMs = windowEndUtc.getTime();
@@ -258,12 +260,17 @@ export class SupabaseBookingStore implements BookingStore {
     return out;
   }
 
-  async markReminderSent(bookingId: string, sentAt: Date): Promise<void> {
+  async markReminderSent(
+    bookingId: string,
+    kind: ReminderKind,
+    sentAt: Date
+  ): Promise<void> {
+    const col = REMINDER_DB_COLUMN[kind];
     const { error } = await this.db
       .from("bookings")
-      .update({ reminder_sent_at: sentAt.toISOString() })
+      .update({ [col]: sentAt.toISOString() })
       .eq("id", bookingId)
-      .is("reminder_sent_at", null);
+      .is(col, null);
     if (error) throw new Error(error.message);
   }
 
@@ -290,8 +297,14 @@ export class SupabaseBookingStore implements BookingStore {
       isAutoBooked: row.is_auto_booked as boolean,
       status: row.status as Booking["status"],
       createdAt: new Date(row.created_at as string),
-      reminderSentAt: row.reminder_sent_at
-        ? new Date(row.reminder_sent_at as string)
+      reminder24hSentAt: row.reminder_24h_sent_at
+        ? new Date(row.reminder_24h_sent_at as string)
+        : null,
+      reminder2hSentAt: row.reminder_2h_sent_at
+        ? new Date(row.reminder_2h_sent_at as string)
+        : null,
+      postSessionPromptSentAt: row.postsession_prompt_sent_at
+        ? new Date(row.postsession_prompt_sent_at as string)
         : null,
     };
   }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -45,6 +45,8 @@ export interface Slot {
 
 export type BookingStatus = "confirmed" | "cancelled" | "no_show";
 
+export type ReminderKind = "reminder_24h" | "reminder_2h" | "post_session";
+
 export interface Booking {
   id: string;
   slotId: string;
@@ -53,7 +55,9 @@ export interface Booking {
   isAutoBooked: boolean;
   status: BookingStatus;
   createdAt: Date;
-  reminderSentAt: Date | null;
+  reminder24hSentAt: Date | null;
+  reminder2hSentAt: Date | null;
+  postSessionPromptSentAt: Date | null;
 }
 
 export interface CoachNote {

--- a/supabase/migrations/00016_phase18_reminder_cadence.sql
+++ b/supabase/migrations/00016_phase18_reminder_cadence.sql
@@ -1,0 +1,28 @@
+-- Phase 18 (#53): reminder cadence retune
+-- Drop the single 1h reminder column + index in favour of three windows:
+--   * 24h before slot start
+--   * 2h before slot start
+--   * 30min after slot end (post-session log prompt)
+-- Each column is independently stamped so the same booking can fire three
+-- distinct pushes without double-sending.
+
+alter table bookings
+  add column if not exists reminder_24h_sent_at timestamptz,
+  add column if not exists reminder_2h_sent_at timestamptz,
+  add column if not exists postsession_prompt_sent_at timestamptz;
+
+drop index if exists bookings_reminder_pending_idx;
+
+create index if not exists bookings_reminder_24h_pending_idx
+  on bookings (slot_id)
+  where status = 'confirmed' and reminder_24h_sent_at is null;
+
+create index if not exists bookings_reminder_2h_pending_idx
+  on bookings (slot_id)
+  where status = 'confirmed' and reminder_2h_sent_at is null;
+
+create index if not exists bookings_postsession_pending_idx
+  on bookings (slot_id)
+  where status = 'confirmed' and postsession_prompt_sent_at is null;
+
+alter table bookings drop column if exists reminder_sent_at;


### PR DESCRIPTION
## Summary
- Drops the 1h-before reminder; replaces it with three independent windows: **24h before**, **2h before**, and **30min after slot end** (post-session log prompt).
- Each kind has its own \`*_sent_at\` column + idempotency guard. Migration 00016 drops the old \`reminder_sent_at\` (pre-launch, single-customer data) and adds three new columns + partial indexes.
- Hebrew copy in \`notification.ts\` per kind. Post-session push silently no-ops until FCM lands (#36) — only mock notifier exists, so it logs, doesn't actually push.
- New \`ReminderKind\` type + \`REMINDER_DB_COLUMN\` map; \`BookingStore.getRemindersDue\` and \`markReminderSent\` now take a \`kind\` param.

## Test plan
- [x] Backend: \`npx vitest run\` → 272/272 (was 265; +7 new cadence tests, -2 obsolete 1h window tests, +others)
- [x] TypeScript: \`npx tsc --noEmit\` clean
- [x] Lint: \`npx eslint src --ext .ts,.tsx\` clean
- [x] Mobile: \`flutter test\` → 109/109 (mobile doesn't touch reminders)

## Acceptance match (issue #53)
- [x] Booking starting in [23h55m, 24h05m] gets one 24h push, exactly once
- [x] Booking starting in [1h55m, 2h05m] gets one 2h push, exactly once
- [x] Booking that ended in last [25m, 35m] gets one post-session prompt, exactly once
- [x] Cancelled / no_show bookings don't get reminded
- [x] Existing 1h reminder code removed (not behind a flag)

## Migration note
\`00016_phase18_reminder_cadence.sql\` drops \`reminder_sent_at\` outright. Acceptable because the app is pre-launch with a single dev coach; any in-flight reminder state is disposable. Roll-forward only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)