### PR TITLE
feat: progress tracking backend — measurement_logs + session_logs (#52, partial)

### DIFF
--- a/DEVELOPMENT_UPDATE.md
+++ b/DEVELOPMENT_UPDATE.md
@@ -50,7 +50,19 @@ Cancel/Reschedule → Outside 24h: trainee acts freely. Inside 24h: trainee subm
 All flows server-enforced via Bookings service. Spec-locked gate order (tests in bookings.test.ts): LOCKOUT (7h) → WEEKLY_LIMIT (2/wk) → SLOT_FULL (capacity) → ALREADY_BOOKED (duplicate). Bypass flag (coach manual add) skips first two.
 
 4. Build Status by Theme
-Latest merge — PR #56 (8 commits, master at 133f992):
+Latest merges:
+
+PR #58 (master at 334da4e) — #53 reminder cadence retune:
+  Drops 1h-before reminder. Three windows: 24h-before, 2h-before, 30min-after-slot-end.
+  Migration 00016 (reminder_24h_sent_at + reminder_2h_sent_at + postsession_prompt_sent_at).
+  ReminderKind type + Hebrew copy per kind. Post-session push silently no-ops until FCM (#36).
+  272/272 backend, 109/109 mobile.
+
+PR #57 — #55 reschedule race fix:
+  Reorders Bookings.decideRequest: book new slot first, then cancel old. Race on full target now
+  returns SLOT_FULL + leaves request pending + old booking intact. ADR-0007.
+
+PR #56 — Epic #54 (40 items, 5 vertical slices):
 
 Epic #54 — UI remediation closed. All 40 items shipped (R1-R40):
   Slice 1 — trainee home: drop dup greeting, hero gradient teal→tealDark, SkeletonList, EmptyState, hero stat trim
@@ -67,9 +79,7 @@ PR #51 (earlier) — phases 11-18 already on master:
 
 Open epics:
 
-#52 — Progress tracking (measurement_logs + session_logs + photos + post-session prompt + fl_chart)
-#53 — Reminder cron retune (drop 1h; add 24h + 2h + post-session)
-#55 — Race: approving reschedule when target slot has since filled strands trainee (latent bug surfaced by PR #56 race test; logic in decideRequest line 445-452 swallows SLOT_FULL from book())
+#52 — Progress tracking (measurement_logs + session_logs + photos + post-session prompt + fl_chart). Backend slice up next.
 
 Open HITL:
 
@@ -80,6 +90,8 @@ Open HITL:
 
 Closed/deprecated:
 
+#53 — Reminder cron retune (closed by PR #58)
+#55 — Reschedule race (closed by PR #57)
 #54 — UI remediation epic (closed by PR #56)
 #1 — original PRD (kept for history; deprecation header points at CONTEXT.md + ADRs)
 
@@ -172,8 +184,6 @@ ADR-0006 — Coach notes are v1 progress primitive (#52 graduates this to v2)
 10. Next Immediate Actions
 Order (vertical slices, no parallelism):
 
-#55 race-condition fix — pick reservation strategy (hold slot at request time vs abort approval on SLOT_FULL); small backend change, real user impact.
-#53 reminder retune — drop 1h cron, add 24h + 2h + post-session columns + cron logic. Post-session push gated on FCM (#36).
 #52 progress tracking backend — measurement_logs + session_logs migrations + APIs + Supabase Storage bucket.
 #52 progress tracking mobile — ProgressTab, MeasurementLoggerSheet, photo timeline (blocked on backend).
 #25 Firebase project setup (HITL) — unblocks #36.

--- a/src/app/api/admin/trainees/[id]/progress/__tests__/route.test.ts
+++ b/src/app/api/admin/trainees/[id]/progress/__tests__/route.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockJwtSession = vi.fn();
+const mockLoadProfile = vi.fn();
+
+vi.mock("@/lib/services/jwt-session", () => ({
+  getJwtSession: (req: NextRequest) => mockJwtSession(req),
+}));
+
+vi.mock("@/lib/auth/profile-repo", () => ({
+  loadProfile: (id: string) => mockLoadProfile(id),
+}));
+
+process.env.MOCK_SERVICES = "true";
+
+import { GET } from "../route";
+import { resetContainer, getContainer } from "@/lib/services";
+import type { Profile } from "@/lib/auth/profile-repo";
+
+const coach: Profile = {
+  userId: "coach-1",
+  email: "coach@example.com",
+  phone: null,
+  name: "Coach",
+  role: "coach",
+  status: "active",
+  hasIntro: true,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const trainee: Profile = {
+  ...coach,
+  userId: "t1",
+  role: "trainee",
+  name: "Alice",
+};
+
+const get = (id: string) =>
+  new NextRequest(`http://localhost/api/admin/trainees/${id}/progress`, {
+    headers: { authorization: "Bearer jwt" },
+  });
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+describe("GET /api/admin/trainees/[id]/progress", () => {
+  beforeEach(() => {
+    resetContainer();
+    mockJwtSession.mockResolvedValue({ userId: "coach-1", email: "coach@example.com" });
+    mockLoadProfile.mockResolvedValue(coach);
+  });
+
+  afterEach(() => {
+    mockJwtSession.mockReset();
+    mockLoadProfile.mockReset();
+  });
+
+  it("returns trainee's measurements newest first", async () => {
+    const { progress } = getContainer();
+    const older = new Date(Date.now() - 10 * 86_400_000);
+    const newer = new Date(Date.now() - 1 * 86_400_000);
+    await progress.createMeasurement("t1", { weightKg: 70, loggedAt: older });
+    await progress.createMeasurement("t1", { weightKg: 71, loggedAt: newer });
+
+    const res = await GET(get("t1"), params("t1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.measurements).toHaveLength(2);
+    expect(body.measurements[0].weightKg).toBe(71);
+    expect(body.lastMeasurement.weightKg).toBe(71);
+  });
+
+  it("403 for a trainee impersonating coach role guard", async () => {
+    mockLoadProfile.mockResolvedValue(trainee);
+    const res = await GET(get("t1"), params("t1"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns empty arrays when no logs exist", async () => {
+    const res = await GET(get("t1"), params("t1"));
+    const body = await res.json();
+    expect(body.measurements).toEqual([]);
+    expect(body.lastMeasurement).toBeNull();
+  });
+});

--- a/src/app/api/admin/trainees/[id]/progress/route.ts
+++ b/src/app/api/admin/trainees/[id]/progress/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getContainer } from "@/lib/services";
+import { requireCoach } from "@/lib/auth/require";
+
+const DEFAULT_DAYS = 90;
+const DEFAULT_LIMIT = 100;
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const r = await requireCoach(request);
+  if ("error" in r) return r.error;
+
+  const { id } = await params;
+  const url = new URL(request.url);
+  const sinceDays = clampInt(url.searchParams.get("days"), DEFAULT_DAYS, 1, 365);
+  const limit = clampInt(url.searchParams.get("limit"), DEFAULT_LIMIT, 1, 500);
+
+  const { progress } = getContainer();
+  const measurements = await progress.listMeasurements(id, { limit, sinceDays });
+  const sessionLogs = await progress.listSessionLogsForTrainee(id, { limit });
+
+  return NextResponse.json({
+    measurements,
+    sessionLogs,
+    lastMeasurement: measurements[0] ?? null,
+  });
+}
+
+function clampInt(raw: string | null, def: number, min: number, max: number) {
+  const n = raw ? Number.parseInt(raw, 10) : NaN;
+  if (Number.isNaN(n)) return def;
+  return Math.min(max, Math.max(min, n));
+}

--- a/src/app/api/me/measurement/__tests__/route.test.ts
+++ b/src/app/api/me/measurement/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockJwtSession = vi.fn();
+const mockLoadProfile = vi.fn();
+
+vi.mock("@/lib/services/jwt-session", () => ({
+  getJwtSession: (req: NextRequest) => mockJwtSession(req),
+}));
+
+vi.mock("@/lib/auth/profile-repo", () => ({
+  loadProfile: (id: string) => mockLoadProfile(id),
+}));
+
+process.env.MOCK_SERVICES = "true";
+
+import { POST } from "../route";
+import { resetContainer, getContainer } from "@/lib/services";
+import type { Profile } from "@/lib/auth/profile-repo";
+
+const trainee: Profile = {
+  userId: "t1",
+  email: "t1@example.com",
+  phone: null,
+  name: "Alice",
+  role: "trainee",
+  status: "active",
+  hasIntro: true,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const post = (body: unknown) =>
+  new NextRequest("http://localhost/api/me/measurement", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer jwt",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+describe("POST /api/me/measurement", () => {
+  beforeEach(() => {
+    resetContainer();
+    mockJwtSession.mockResolvedValue({ userId: "t1", email: "t1@example.com" });
+    mockLoadProfile.mockResolvedValue(trainee);
+  });
+
+  afterEach(() => {
+    mockJwtSession.mockReset();
+    mockLoadProfile.mockReset();
+  });
+
+  it("creates a measurement with just a weight", async () => {
+    const res = await POST(post({ weightKg: 73.4 }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.measurement).toMatchObject({ traineeId: "t1", weightKg: 73.4 });
+  });
+
+  it("rejects empty body with EMPTY_PAYLOAD", async () => {
+    const res = await POST(post({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("EMPTY_PAYLOAD");
+  });
+
+  it("rejects implausible weight with INVALID_WEIGHT", async () => {
+    const res = await POST(post({ weightKg: 999 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("INVALID_WEIGHT");
+  });
+
+  it("stamps traineeId from session, ignoring any client-sent id", async () => {
+    await POST(post({ weightKg: 70 }));
+    const { progress } = getContainer();
+    const list = await progress.listMeasurements("t1");
+    expect(list).toHaveLength(1);
+    expect(list[0].traineeId).toBe("t1");
+  });
+
+  it("403 for pending trainee", async () => {
+    mockLoadProfile.mockResolvedValue({ ...trainee, status: "pending" });
+    const res = await POST(post({ weightKg: 73 }));
+    expect(res.status).toBe(403);
+  });
+
+  it("accepts photo-only payload (no weight)", async () => {
+    const res = await POST(post({ photoUrl: "https://example.com/p.jpg" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.measurement.photoUrl).toBe("https://example.com/p.jpg");
+    expect(body.measurement.weightKg).toBeNull();
+  });
+});

--- a/src/app/api/me/measurement/route.ts
+++ b/src/app/api/me/measurement/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getContainer } from "@/lib/services";
+import { requireActiveTrainee } from "@/lib/auth/require";
+import { MeasurementValidationError } from "@/lib/services/progress-store";
+
+interface Body {
+  weightKg?: number | null;
+  metrics?: Record<string, unknown> | null;
+  photoUrl?: string | null;
+  note?: string | null;
+  loggedAt?: string;
+}
+
+export async function POST(request: NextRequest) {
+  const r = await requireActiveTrainee(request);
+  if ("error" in r) return r.error;
+
+  const body = (await request.json()) as Body;
+  const { progress } = getContainer();
+
+  try {
+    const row = await progress.createMeasurement(r.trainee.userId, {
+      weightKg: body.weightKg ?? null,
+      metrics: body.metrics ?? null,
+      photoUrl: body.photoUrl ?? null,
+      note: body.note ?? null,
+      loggedAt: body.loggedAt ? new Date(body.loggedAt) : undefined,
+    });
+    return NextResponse.json({ measurement: row });
+  } catch (e) {
+    if (e instanceof MeasurementValidationError) {
+      return NextResponse.json(
+        { error: e.code, message: e.message },
+        { status: 400 }
+      );
+    }
+    throw e;
+  }
+}

--- a/src/app/api/me/progress/__tests__/route.test.ts
+++ b/src/app/api/me/progress/__tests__/route.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockJwtSession = vi.fn();
+const mockLoadProfile = vi.fn();
+
+vi.mock("@/lib/services/jwt-session", () => ({
+  getJwtSession: (req: NextRequest) => mockJwtSession(req),
+}));
+
+vi.mock("@/lib/auth/profile-repo", () => ({
+  loadProfile: (id: string) => mockLoadProfile(id),
+}));
+
+process.env.MOCK_SERVICES = "true";
+
+import { GET } from "../route";
+import { getContainer, resetContainer } from "@/lib/services";
+import type { Profile } from "@/lib/auth/profile-repo";
+
+const trainee: Profile = {
+  userId: "t1",
+  email: "t1@example.com",
+  phone: null,
+  name: "Alice",
+  role: "trainee",
+  status: "active",
+  hasIntro: true,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const req = (qs = "") =>
+  new NextRequest(`http://localhost/api/me/progress${qs}`, {
+    headers: { authorization: "Bearer jwt" },
+  });
+
+describe("GET /api/me/progress", () => {
+  beforeEach(() => {
+    resetContainer();
+    mockJwtSession.mockResolvedValue({ userId: "t1", email: "t1@example.com" });
+    mockLoadProfile.mockResolvedValue(trainee);
+  });
+
+  afterEach(() => {
+    mockJwtSession.mockReset();
+    mockLoadProfile.mockReset();
+  });
+
+  it("returns empty arrays for a fresh trainee", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      measurements: [],
+      sessionLogs: [],
+      lastMeasurement: null,
+    });
+  });
+
+  it("returns measurements newest first with lastMeasurement", async () => {
+    const { progress } = getContainer();
+    const older = new Date(Date.now() - 10 * 86_400_000);
+    const newer = new Date(Date.now() - 1 * 86_400_000);
+    await progress.createMeasurement("t1", { weightKg: 70, loggedAt: older });
+    await progress.createMeasurement("t1", { weightKg: 71, loggedAt: newer });
+
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.measurements).toHaveLength(2);
+    expect(body.measurements[0].weightKg).toBe(71);
+    expect(body.lastMeasurement.weightKg).toBe(71);
+  });
+
+  it("respects ?days=N filter", async () => {
+    const { progress } = getContainer();
+    await progress.createMeasurement("t1", {
+      weightKg: 60,
+      loggedAt: new Date(Date.now() - 200 * 86_400_000),
+    });
+    await progress.createMeasurement("t1", { weightKg: 70 });
+
+    const res = await GET(req("?days=30"));
+    const body = await res.json();
+    expect(body.measurements).toHaveLength(1);
+    expect(body.measurements[0].weightKg).toBe(70);
+  });
+
+  it("403 for non-active trainee", async () => {
+    mockLoadProfile.mockResolvedValue({ ...trainee, status: "pending" });
+    const res = await GET(req());
+    expect(res.status).toBe(403);
+  });
+
+  it("does not leak other trainees' rows", async () => {
+    const { progress } = getContainer();
+    await progress.createMeasurement("t1", { weightKg: 71 });
+    await progress.createMeasurement("t2", { weightKg: 95 });
+
+    const res = await GET(req());
+    const body = await res.json();
+    expect(body.measurements).toHaveLength(1);
+    expect(body.measurements[0].weightKg).toBe(71);
+  });
+});

--- a/src/app/api/me/progress/route.ts
+++ b/src/app/api/me/progress/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getContainer } from "@/lib/services";
+import { requireActiveTrainee } from "@/lib/auth/require";
+
+const DEFAULT_DAYS = 90;
+const DEFAULT_LIMIT = 50;
+
+/** Trainee's own progress: measurements (last 90 days by default) + session logs. */
+export async function GET(request: NextRequest) {
+  const r = await requireActiveTrainee(request);
+  if ("error" in r) return r.error;
+
+  const url = new URL(request.url);
+  const sinceDays = clampInt(url.searchParams.get("days"), DEFAULT_DAYS, 1, 365);
+  const limit = clampInt(url.searchParams.get("limit"), DEFAULT_LIMIT, 1, 200);
+
+  const { progress } = getContainer();
+  const measurements = await progress.listMeasurements(r.trainee.userId, {
+    limit,
+    sinceDays,
+  });
+  const sessionLogs = await progress.listSessionLogsForTrainee(r.trainee.userId, {
+    limit,
+  });
+
+  return NextResponse.json({
+    measurements,
+    sessionLogs,
+    lastMeasurement: measurements[0] ?? null,
+  });
+}
+
+function clampInt(raw: string | null, def: number, min: number, max: number) {
+  const n = raw ? Number.parseInt(raw, 10) : NaN;
+  if (Number.isNaN(n)) return def;
+  return Math.min(max, Math.max(min, n));
+}

--- a/src/app/api/me/session-log/[bookingId]/__tests__/route.test.ts
+++ b/src/app/api/me/session-log/[bookingId]/__tests__/route.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockJwtSession = vi.fn();
+const mockLoadProfile = vi.fn();
+
+vi.mock("@/lib/services/jwt-session", () => ({
+  getJwtSession: (req: NextRequest) => mockJwtSession(req),
+}));
+
+vi.mock("@/lib/auth/profile-repo", () => ({
+  loadProfile: (id: string) => mockLoadProfile(id),
+}));
+
+process.env.MOCK_SERVICES = "true";
+
+import { POST, GET } from "../route";
+import { resetContainer, getContainer } from "@/lib/services";
+import type { Profile } from "@/lib/auth/profile-repo";
+
+const trainee: Profile = {
+  userId: "t1",
+  email: "t1@example.com",
+  phone: null,
+  name: "Alice",
+  role: "trainee",
+  status: "active",
+  hasIntro: true,
+  createdAt: "2026-01-01T00:00:00Z",
+};
+
+const post = (bookingId: string, body: unknown) =>
+  new NextRequest(`http://localhost/api/me/session-log/${bookingId}`, {
+    method: "POST",
+    headers: {
+      authorization: "Bearer jwt",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+const get = (bookingId: string) =>
+  new NextRequest(`http://localhost/api/me/session-log/${bookingId}`, {
+    headers: { authorization: "Bearer jwt" },
+  });
+
+const params = (bookingId: string) => ({
+  params: Promise.resolve({ bookingId }),
+});
+
+describe("POST /api/me/session-log/[bookingId]", () => {
+  beforeEach(() => {
+    resetContainer();
+    mockJwtSession.mockResolvedValue({ userId: "t1", email: "t1@example.com" });
+    mockLoadProfile.mockResolvedValue(trainee);
+  });
+
+  afterEach(() => {
+    mockJwtSession.mockReset();
+    mockLoadProfile.mockReset();
+  });
+
+  async function seedBookingForT1() {
+    const { store, bookings } = getContainer();
+    store.upsertSlot({
+      id: "s1",
+      date: "2026-04-01",
+      startTime: "10:00",
+      capacity: 2,
+      lockoutOverride: false,
+      currentBookings: 0,
+    });
+    const b = await bookings.book("t1", "s1", { bypass: true });
+    if (!b.ok) throw new Error("setup failed");
+    return b.booking.id;
+  }
+
+  it("creates a session log for caller's own booking", async () => {
+    const bookingId = await seedBookingForT1();
+    const res = await POST(post(bookingId, { feedback: { energy: 4 } }), params(bookingId));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sessionLog.feedback).toEqual({ energy: 4 });
+  });
+
+  it("upsert is idempotent: second POST updates feedback", async () => {
+    const bookingId = await seedBookingForT1();
+    await POST(post(bookingId, { feedback: { energy: 3 } }), params(bookingId));
+    const res = await POST(post(bookingId, { feedback: { energy: 5 } }), params(bookingId));
+    const body = await res.json();
+    expect(body.sessionLog.feedback).toEqual({ energy: 5 });
+  });
+
+  it("404 when booking is not the caller's", async () => {
+    const { store, bookings } = getContainer();
+    store.upsertSlot({
+      id: "s1",
+      date: "2026-04-01",
+      startTime: "10:00",
+      capacity: 2,
+      lockoutOverride: false,
+      currentBookings: 0,
+    });
+    const b = await bookings.book("t2", "s1", { bypass: true });
+    if (!b.ok) throw new Error("setup failed");
+
+    const res = await POST(post(b.booking.id, { feedback: { energy: 3 } }), params(b.booking.id));
+    expect(res.status).toBe(404);
+  });
+
+  it("404 when booking doesn't exist", async () => {
+    const res = await POST(post("ghost", { feedback: {} }), params("ghost"));
+    expect(res.status).toBe(404);
+  });
+
+  it("trainee cannot write coach_notes via this route (silently dropped)", async () => {
+    const bookingId = await seedBookingForT1();
+    await POST(
+      post(bookingId, { feedback: { energy: 4 }, coachNotes: "I am sneaky" }),
+      params(bookingId)
+    );
+    const { progress } = getContainer();
+    const row = await progress.getSessionLog(bookingId);
+    expect(row?.coachNotes).toBeNull();
+  });
+});
+
+describe("GET /api/me/session-log/[bookingId]", () => {
+  beforeEach(() => {
+    resetContainer();
+    mockJwtSession.mockResolvedValue({ userId: "t1", email: "t1@example.com" });
+    mockLoadProfile.mockResolvedValue(trainee);
+  });
+
+  afterEach(() => {
+    mockJwtSession.mockReset();
+    mockLoadProfile.mockReset();
+  });
+
+  it("returns null when no log exists yet", async () => {
+    const { store, bookings } = getContainer();
+    store.upsertSlot({
+      id: "s1",
+      date: "2026-04-01",
+      startTime: "10:00",
+      capacity: 2,
+      lockoutOverride: false,
+      currentBookings: 0,
+    });
+    const b = await bookings.book("t1", "s1", { bypass: true });
+    if (!b.ok) throw new Error("setup failed");
+
+    const res = await GET(get(b.booking.id), params(b.booking.id));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sessionLog).toBeNull();
+  });
+});

--- a/src/app/api/me/session-log/[bookingId]/route.ts
+++ b/src/app/api/me/session-log/[bookingId]/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getContainer } from "@/lib/services";
+import { requireActiveTrainee } from "@/lib/auth/require";
+
+interface Body {
+  feedback?: Record<string, unknown> | null;
+  coachNotes?: string | null;
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ bookingId: string }> }
+) {
+  const r = await requireActiveTrainee(request);
+  if ("error" in r) return r.error;
+
+  const { bookingId } = await params;
+  const { store, progress } = getContainer();
+
+  const booking = await store.getBooking(bookingId);
+  if (!booking || booking.traineeId !== r.trainee.userId) {
+    return NextResponse.json(
+      { error: "NOT_FOUND", message: "Booking not found" },
+      { status: 404 }
+    );
+  }
+
+  const body = (await request.json()) as Body;
+  // Trainee may only write feedback. Coach notes are coach-only (different route).
+  const row = await progress.upsertSessionLog(bookingId, {
+    feedback: body.feedback ?? null,
+  });
+  return NextResponse.json({ sessionLog: row });
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ bookingId: string }> }
+) {
+  const r = await requireActiveTrainee(request);
+  if ("error" in r) return r.error;
+
+  const { bookingId } = await params;
+  const { store, progress } = getContainer();
+
+  const booking = await store.getBooking(bookingId);
+  if (!booking || booking.traineeId !== r.trainee.userId) {
+    return NextResponse.json(
+      { error: "NOT_FOUND", message: "Booking not found" },
+      { status: 404 }
+    );
+  }
+
+  const row = await progress.getSessionLog(bookingId);
+  return NextResponse.json({ sessionLog: row ?? null });
+}

--- a/src/lib/__tests__/progress-store.test.ts
+++ b/src/lib/__tests__/progress-store.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  MockProgressStore,
+  MeasurementValidationError,
+  validateMeasurementInput,
+} from "@/lib/services/progress-store";
+
+describe("MockProgressStore — measurements", () => {
+  let store: MockProgressStore;
+  beforeEach(() => {
+    store = new MockProgressStore();
+  });
+
+  it("creates a measurement with just a weight", async () => {
+    const m = await store.createMeasurement("t1", { weightKg: 72.5 });
+    expect(m).toMatchObject({ traineeId: "t1", weightKg: 72.5, photoUrl: null });
+    expect(m.id).toMatch(/^ml-/);
+    expect(m.loggedAt).toBeInstanceOf(Date);
+  });
+
+  it("rejects an empty payload", async () => {
+    await expect(store.createMeasurement("t1", {})).rejects.toThrow(
+      MeasurementValidationError
+    );
+  });
+
+  it("rejects implausible weight (negative or > 500kg)", async () => {
+    await expect(
+      store.createMeasurement("t1", { weightKg: -10 })
+    ).rejects.toMatchObject({ code: "INVALID_WEIGHT" });
+    await expect(
+      store.createMeasurement("t1", { weightKg: 600 })
+    ).rejects.toMatchObject({ code: "INVALID_WEIGHT" });
+  });
+
+  it("accepts a row with only metrics", async () => {
+    const m = await store.createMeasurement("t1", {
+      metrics: { energy: 4, soreness: 2 },
+    });
+    expect(m.metrics).toEqual({ energy: 4, soreness: 2 });
+  });
+
+  it("accepts a row with only a photo", async () => {
+    const m = await store.createMeasurement("t1", {
+      photoUrl: "https://example.com/p.jpg",
+    });
+    expect(m.photoUrl).toBe("https://example.com/p.jpg");
+  });
+
+  it("rejects whitespace-only note as empty", async () => {
+    await expect(
+      store.createMeasurement("t1", { note: "   " })
+    ).rejects.toMatchObject({ code: "EMPTY_PAYLOAD" });
+  });
+
+  it("trims notes on insert", async () => {
+    const m = await store.createMeasurement("t1", { note: "  felt strong  " });
+    expect(m.note).toBe("felt strong");
+  });
+
+  it("lists newest first; per-trainee scoped", async () => {
+    await store.createMeasurement("t1", {
+      weightKg: 70,
+      loggedAt: new Date("2026-01-01"),
+    });
+    await store.createMeasurement("t1", {
+      weightKg: 71,
+      loggedAt: new Date("2026-02-01"),
+    });
+    await store.createMeasurement("t2", { weightKg: 99 });
+
+    const list = await store.listMeasurements("t1");
+    expect(list).toHaveLength(2);
+    expect(list[0].weightKg).toBe(71);
+    expect(list[1].weightKg).toBe(70);
+  });
+
+  it("respects sinceDays filter", async () => {
+    const longAgo = new Date(Date.now() - 200 * 86_400_000);
+    await store.createMeasurement("t1", { weightKg: 65, loggedAt: longAgo });
+    await store.createMeasurement("t1", { weightKg: 66 });
+
+    const last90 = await store.listMeasurements("t1", { sinceDays: 90 });
+    expect(last90).toHaveLength(1);
+    expect(last90[0].weightKg).toBe(66);
+  });
+
+  it("getLastMeasurement returns the newest", async () => {
+    await store.createMeasurement("t1", {
+      weightKg: 70,
+      loggedAt: new Date("2026-01-01"),
+    });
+    await store.createMeasurement("t1", {
+      weightKg: 71,
+      loggedAt: new Date("2026-02-01"),
+    });
+    const last = await store.getLastMeasurement("t1");
+    expect(last?.weightKg).toBe(71);
+  });
+});
+
+describe("MockProgressStore — session logs", () => {
+  let store: MockProgressStore;
+  beforeEach(() => {
+    store = new MockProgressStore();
+  });
+
+  it("upsert creates then updates idempotently", async () => {
+    const a = await store.upsertSessionLog("b1", {
+      feedback: { energy: 3 },
+    });
+    expect(a.feedback).toEqual({ energy: 3 });
+
+    const b = await store.upsertSessionLog("b1", {
+      feedback: { energy: 5, free_text: "great" },
+    });
+    expect(b.feedback).toEqual({ energy: 5, free_text: "great" });
+    expect(b.createdAt).toEqual(a.createdAt);
+    expect(b.updatedAt.getTime()).toBeGreaterThanOrEqual(a.updatedAt.getTime());
+  });
+
+  it("partial update preserves other fields", async () => {
+    await store.upsertSessionLog("b1", { feedback: { energy: 4 } });
+    await store.upsertSessionLog("b1", { coachNotes: "good form on squats" });
+
+    const r = await store.getSessionLog("b1");
+    expect(r?.feedback).toEqual({ energy: 4 });
+    expect(r?.coachNotes).toBe("good form on squats");
+  });
+
+  it("getSessionLog returns undefined for unknown booking", async () => {
+    expect(await store.getSessionLog("ghost")).toBeUndefined();
+  });
+});
+
+describe("validateMeasurementInput — guard", () => {
+  it("treats empty metrics object as empty", () => {
+    expect(() => validateMeasurementInput({ metrics: {} })).toThrow();
+  });
+
+  it("treats empty photoUrl string as empty", () => {
+    expect(() => validateMeasurementInput({ photoUrl: "" })).toThrow();
+  });
+
+  it("accepts zero-decimal weight", () => {
+    expect(() => validateMeasurementInput({ weightKg: 72 })).not.toThrow();
+  });
+});

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -6,9 +6,11 @@ import { AuthService } from "./auth";
 import { BookingStore, MockBookingStore } from "./booking-store";
 import { NotificationService, MockNotificationService } from "./notification";
 import { Bookings, makeBookings } from "./bookings";
+import { ProgressStore, MockProgressStore } from "./progress-store";
 import { CoachReadModel } from "@/lib/coach/read-model";
 import { makeCoachReadModel } from "@/lib/coach/mock-read-model";
 import { SupabaseBookingStore } from "@/lib/supabase/booking-store";
+import { SupabaseProgressStore } from "@/lib/supabase/progress-store";
 import { SupabaseAuthService, MockAuthService } from "@/lib/supabase/auth-service";
 import { getSupabaseClient, getSupabaseAdminClient } from "@/lib/supabase/client";
 
@@ -26,6 +28,7 @@ let tokenStore: TokenStore;
 let authService: AuthService;
 let bookingStore: BookingStore;
 let notificationService: NotificationService;
+let progressStore: ProgressStore;
 
 export function getTokenStore(): TokenStore {
   if (!tokenStore) tokenStore = new InMemoryTokenStore();
@@ -74,6 +77,15 @@ export function getNotificationService(): NotificationService {
   return notificationService;
 }
 
+export function getProgressStore(): ProgressStore {
+  if (!progressStore) {
+    progressStore = isFullMock()
+      ? new MockProgressStore()
+      : new SupabaseProgressStore(getSupabaseAdminClient());
+  }
+  return progressStore;
+}
+
 /**
  * Container — unified facade over the booking domain.
  *
@@ -85,6 +97,7 @@ export interface Container {
   bookings: Bookings;
   auth: AuthService;
   coachRead: CoachReadModel;
+  progress: ProgressStore;
 }
 
 let _container: Container | null = null;
@@ -103,6 +116,7 @@ export function resetContainer(): void {
   authService = undefined!;
   bookingStore = undefined!;
   notificationService = undefined!;
+  progressStore = undefined!;
 }
 
 function buildContainer(): Container {
@@ -112,5 +126,6 @@ function buildContainer(): Container {
   const bookings = makeBookings(store, calendar, notifier);
   const auth = getAuthService();
   const coachRead = makeCoachReadModel(store, auth, bookings);
-  return { store, bookings, auth, coachRead };
+  const progress = getProgressStore();
+  return { store, bookings, auth, coachRead, progress };
 }

--- a/src/lib/services/progress-store.ts
+++ b/src/lib/services/progress-store.ts
@@ -1,0 +1,140 @@
+import type {
+  MeasurementLog,
+  MeasurementInput,
+  SessionLog,
+  SessionLogInput,
+} from "@/lib/types";
+
+/**
+ * ProgressStore — measurement_logs + session_logs persistence.
+ *
+ * Service-role backed; route handlers gate access via require* helpers,
+ * RLS on the table is for the eventual direct-from-client case.
+ */
+export interface ProgressStore {
+  createMeasurement(
+    traineeId: string,
+    input: MeasurementInput
+  ): Promise<MeasurementLog>;
+  listMeasurements(
+    traineeId: string,
+    opts?: { limit?: number; sinceDays?: number }
+  ): Promise<MeasurementLog[]>;
+  getLastMeasurement(traineeId: string): Promise<MeasurementLog | undefined>;
+
+  upsertSessionLog(
+    bookingId: string,
+    input: SessionLogInput
+  ): Promise<SessionLog>;
+  getSessionLog(bookingId: string): Promise<SessionLog | undefined>;
+  listSessionLogsForTrainee(
+    traineeId: string,
+    opts?: { limit?: number }
+  ): Promise<SessionLog[]>;
+}
+
+export class MeasurementValidationError extends Error {
+  constructor(public code: "EMPTY_PAYLOAD" | "INVALID_WEIGHT", message: string) {
+    super(message);
+    this.name = "MeasurementValidationError";
+  }
+}
+
+export function validateMeasurementInput(input: MeasurementInput): void {
+  const hasField =
+    input.weightKg != null ||
+    (input.metrics != null && Object.keys(input.metrics).length > 0) ||
+    (input.photoUrl != null && input.photoUrl.length > 0) ||
+    (input.note != null && input.note.trim().length > 0);
+  if (!hasField) {
+    throw new MeasurementValidationError(
+      "EMPTY_PAYLOAD",
+      "Measurement log requires at least one field"
+    );
+  }
+  if (input.weightKg != null && (input.weightKg <= 0 || input.weightKg >= 500)) {
+    throw new MeasurementValidationError(
+      "INVALID_WEIGHT",
+      "weightKg must be > 0 and < 500"
+    );
+  }
+}
+
+/** In-memory store for tests + dev. */
+export class MockProgressStore implements ProgressStore {
+  private measurements = new Map<string, MeasurementLog>();
+  private sessionLogs = new Map<string, SessionLog>();
+
+  async createMeasurement(
+    traineeId: string,
+    input: MeasurementInput
+  ): Promise<MeasurementLog> {
+    validateMeasurementInput(input);
+    const row: MeasurementLog = {
+      id: `ml-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      traineeId,
+      loggedAt: input.loggedAt ?? new Date(),
+      weightKg: input.weightKg ?? null,
+      metrics: input.metrics ?? null,
+      photoUrl: input.photoUrl ?? null,
+      note: input.note?.trim() ? input.note.trim() : null,
+    };
+    this.measurements.set(row.id, row);
+    return { ...row };
+  }
+
+  async listMeasurements(
+    traineeId: string,
+    opts: { limit?: number; sinceDays?: number } = {}
+  ): Promise<MeasurementLog[]> {
+    const cutoff = opts.sinceDays
+      ? Date.now() - opts.sinceDays * 86_400_000
+      : -Infinity;
+    const out = Array.from(this.measurements.values())
+      .filter((m) => m.traineeId === traineeId && m.loggedAt.getTime() >= cutoff)
+      .sort((a, b) => b.loggedAt.getTime() - a.loggedAt.getTime());
+    return opts.limit ? out.slice(0, opts.limit).map((m) => ({ ...m })) : out.map((m) => ({ ...m }));
+  }
+
+  async getLastMeasurement(
+    traineeId: string
+  ): Promise<MeasurementLog | undefined> {
+    const list = await this.listMeasurements(traineeId, { limit: 1 });
+    return list[0];
+  }
+
+  async upsertSessionLog(
+    bookingId: string,
+    input: SessionLogInput
+  ): Promise<SessionLog> {
+    const existing = this.sessionLogs.get(bookingId);
+    const now = new Date();
+    const row: SessionLog = existing
+      ? {
+          ...existing,
+          feedback: input.feedback !== undefined ? input.feedback : existing.feedback,
+          coachNotes:
+            input.coachNotes !== undefined ? input.coachNotes : existing.coachNotes,
+          updatedAt: now,
+        }
+      : {
+          bookingId,
+          feedback: input.feedback ?? null,
+          coachNotes: input.coachNotes ?? null,
+          createdAt: now,
+          updatedAt: now,
+        };
+    this.sessionLogs.set(bookingId, row);
+    return { ...row };
+  }
+
+  async getSessionLog(bookingId: string): Promise<SessionLog | undefined> {
+    const r = this.sessionLogs.get(bookingId);
+    return r ? { ...r } : undefined;
+  }
+
+  async listSessionLogsForTrainee(): Promise<SessionLog[]> {
+    // Mock can't easily join to bookings. Returns all rows; tests should filter.
+    return Array.from(this.sessionLogs.values()).map((r) => ({ ...r }));
+  }
+}

--- a/src/lib/supabase/progress-store.ts
+++ b/src/lib/supabase/progress-store.ts
@@ -1,0 +1,123 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import type {
+  MeasurementLog,
+  MeasurementInput,
+  SessionLog,
+  SessionLogInput,
+} from "@/lib/types";
+import { ProgressStore, validateMeasurementInput } from "@/lib/services/progress-store";
+
+export class SupabaseProgressStore implements ProgressStore {
+  constructor(private db: SupabaseClient) {}
+
+  async createMeasurement(
+    traineeId: string,
+    input: MeasurementInput
+  ): Promise<MeasurementLog> {
+    validateMeasurementInput(input);
+    const insert: Record<string, unknown> = {
+      trainee_id: traineeId,
+      weight_kg: input.weightKg ?? null,
+      metrics: input.metrics ?? null,
+      photo_url: input.photoUrl ?? null,
+      note: input.note?.trim() ? input.note.trim() : null,
+    };
+    if (input.loggedAt) insert.logged_at = input.loggedAt.toISOString();
+    const { data, error } = await this.db
+      .from("measurement_logs")
+      .insert(insert)
+      .select("*")
+      .single();
+    if (error || !data) throw new Error(error?.message ?? "insert failed");
+    return this.mapMeasurement(data);
+  }
+
+  async listMeasurements(
+    traineeId: string,
+    opts: { limit?: number; sinceDays?: number } = {}
+  ): Promise<MeasurementLog[]> {
+    let q = this.db
+      .from("measurement_logs")
+      .select("*")
+      .eq("trainee_id", traineeId)
+      .order("logged_at", { ascending: false });
+    if (opts.sinceDays) {
+      const cutoff = new Date(Date.now() - opts.sinceDays * 86_400_000).toISOString();
+      q = q.gte("logged_at", cutoff);
+    }
+    if (opts.limit) q = q.limit(opts.limit);
+    const { data } = await q;
+    return (data ?? []).map((r: Record<string, unknown>) => this.mapMeasurement(r));
+  }
+
+  async getLastMeasurement(
+    traineeId: string
+  ): Promise<MeasurementLog | undefined> {
+    const rows = await this.listMeasurements(traineeId, { limit: 1 });
+    return rows[0];
+  }
+
+  async upsertSessionLog(
+    bookingId: string,
+    input: SessionLogInput
+  ): Promise<SessionLog> {
+    const patch: Record<string, unknown> = {
+      booking_id: bookingId,
+      updated_at: new Date().toISOString(),
+    };
+    if (input.feedback !== undefined) patch.feedback = input.feedback;
+    if (input.coachNotes !== undefined) patch.coach_notes = input.coachNotes;
+    const { data, error } = await this.db
+      .from("session_logs")
+      .upsert(patch, { onConflict: "booking_id" })
+      .select("*")
+      .single();
+    if (error || !data) throw new Error(error?.message ?? "upsert failed");
+    return this.mapSessionLog(data);
+  }
+
+  async getSessionLog(bookingId: string): Promise<SessionLog | undefined> {
+    const { data } = await this.db
+      .from("session_logs")
+      .select("*")
+      .eq("booking_id", bookingId)
+      .maybeSingle();
+    return data ? this.mapSessionLog(data) : undefined;
+  }
+
+  async listSessionLogsForTrainee(
+    traineeId: string,
+    opts: { limit?: number } = {}
+  ): Promise<SessionLog[]> {
+    let q = this.db
+      .from("session_logs")
+      .select("*, bookings!inner(trainee_id)")
+      .eq("bookings.trainee_id", traineeId)
+      .order("updated_at", { ascending: false });
+    if (opts.limit) q = q.limit(opts.limit);
+    const { data } = await q;
+    return (data ?? []).map((r: Record<string, unknown>) => this.mapSessionLog(r));
+  }
+
+  private mapMeasurement(row: Record<string, unknown>): MeasurementLog {
+    return {
+      id: row.id as string,
+      traineeId: row.trainee_id as string,
+      loggedAt: new Date(row.logged_at as string),
+      weightKg: row.weight_kg != null ? Number(row.weight_kg) : null,
+      metrics: (row.metrics as Record<string, unknown> | null) ?? null,
+      photoUrl: (row.photo_url as string) ?? null,
+      note: (row.note as string) ?? null,
+    };
+  }
+
+  private mapSessionLog(row: Record<string, unknown>): SessionLog {
+    return {
+      bookingId: row.booking_id as string,
+      feedback: (row.feedback as Record<string, unknown> | null) ?? null,
+      coachNotes: (row.coach_notes as string) ?? null,
+      createdAt: new Date(row.created_at as string),
+      updatedAt: new Date(row.updated_at as string),
+    };
+  }
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -90,3 +90,35 @@ export interface EditLog {
   weekStart: string; // YYYY-MM-DD (Sunday)
   editCount: number;
 }
+
+export interface MeasurementLog {
+  id: string;
+  traineeId: string;
+  loggedAt: Date;
+  weightKg: number | null;
+  metrics: Record<string, unknown> | null;
+  photoUrl: string | null;
+  note: string | null;
+}
+
+export interface MeasurementInput {
+  weightKg?: number | null;
+  metrics?: Record<string, unknown> | null;
+  photoUrl?: string | null;
+  note?: string | null;
+  /** Override the logged_at timestamp (e.g., post-session prompt uses session end). Defaults to now. */
+  loggedAt?: Date;
+}
+
+export interface SessionLog {
+  bookingId: string;
+  feedback: Record<string, unknown> | null;
+  coachNotes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface SessionLogInput {
+  feedback?: Record<string, unknown> | null;
+  coachNotes?: string | null;
+}

--- a/supabase/migrations/00017_phase19_measurement_logs.sql
+++ b/supabase/migrations/00017_phase19_measurement_logs.sql
@@ -1,0 +1,44 @@
+-- Phase 19 (#52) — measurement_logs: trainee-owned weight/photo/free-metric log.
+-- Coach can read any trainee's rows; trainees rw their own. Backend uses service-role.
+
+create table if not exists measurement_logs (
+  id           uuid primary key default gen_random_uuid(),
+  trainee_id   uuid not null references profiles(id) on delete cascade,
+  logged_at    timestamptz not null default now(),
+  weight_kg    numeric(5,2) check (weight_kg is null or (weight_kg > 0 and weight_kg < 500)),
+  metrics      jsonb,
+  photo_url    text,
+  note         text,
+  created_at   timestamptz not null default now()
+);
+
+create index if not exists measurement_logs_trainee_logged_idx
+  on measurement_logs (trainee_id, logged_at desc);
+
+-- Reject rows where every payload field is null (no-op log).
+alter table measurement_logs
+  add constraint measurement_logs_not_empty
+  check (
+    weight_kg is not null
+    or metrics is not null
+    or photo_url is not null
+    or (note is not null and length(trim(note)) > 0)
+  );
+
+alter table measurement_logs enable row level security;
+
+drop policy if exists ml_self_select on measurement_logs;
+create policy ml_self_select on measurement_logs
+  for select using (trainee_id = auth.uid());
+
+drop policy if exists ml_self_insert on measurement_logs;
+create policy ml_self_insert on measurement_logs
+  for insert with check (trainee_id = auth.uid());
+
+drop policy if exists ml_self_update on measurement_logs;
+create policy ml_self_update on measurement_logs
+  for update using (trainee_id = auth.uid());
+
+drop policy if exists ml_self_delete on measurement_logs;
+create policy ml_self_delete on measurement_logs
+  for delete using (trainee_id = auth.uid());

--- a/supabase/migrations/00018_phase19_session_logs.sql
+++ b/supabase/migrations/00018_phase19_session_logs.sql
@@ -1,0 +1,45 @@
+-- Phase 19 (#52) — session_logs: per-booking post-session feedback (trainee) + coach notes.
+-- One row per booking (1:1). Trainee writes/edits feedback; coach writes coach_notes.
+
+create table if not exists session_logs (
+  booking_id   uuid primary key references bookings(id) on delete cascade,
+  feedback     jsonb,
+  coach_notes  text,
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now()
+);
+
+create index if not exists session_logs_updated_idx
+  on session_logs (updated_at desc);
+
+alter table session_logs enable row level security;
+
+drop policy if exists sl_trainee_select on session_logs;
+create policy sl_trainee_select on session_logs
+  for select using (
+    exists (
+      select 1 from bookings b
+      where b.id = session_logs.booking_id
+        and b.trainee_id = auth.uid()
+    )
+  );
+
+drop policy if exists sl_trainee_upsert on session_logs;
+create policy sl_trainee_upsert on session_logs
+  for insert with check (
+    exists (
+      select 1 from bookings b
+      where b.id = session_logs.booking_id
+        and b.trainee_id = auth.uid()
+    )
+  );
+
+drop policy if exists sl_trainee_update on session_logs;
+create policy sl_trainee_update on session_logs
+  for update using (
+    exists (
+      select 1 from bookings b
+      where b.id = session_logs.booking_id
+        and b.trainee_id = auth.uid()
+    )
+  );

--- a/supabase/migrations/00019_phase19_progress_photos_bucket.sql
+++ b/supabase/migrations/00019_phase19_progress_photos_bucket.sql
@@ -1,0 +1,41 @@
+-- Phase 19 (#52) — progress-photos storage bucket.
+-- Trainees write to <user_id>/* folder; coach reads everything.
+-- Backend route handlers stamp photo_url on measurement_logs; clients upload directly.
+
+insert into storage.buckets (id, name, public)
+values ('progress-photos', 'progress-photos', false)
+on conflict (id) do nothing;
+
+-- Trainee can write inside their own folder (path starts with their uid).
+drop policy if exists progress_trainee_insert on storage.objects;
+create policy progress_trainee_insert on storage.objects
+  for insert with check (
+    bucket_id = 'progress-photos'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+drop policy if exists progress_trainee_select_own on storage.objects;
+create policy progress_trainee_select_own on storage.objects
+  for select using (
+    bucket_id = 'progress-photos'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+drop policy if exists progress_trainee_delete_own on storage.objects;
+create policy progress_trainee_delete_own on storage.objects
+  for delete using (
+    bucket_id = 'progress-photos'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Coach reads everything in the bucket.
+drop policy if exists progress_coach_select on storage.objects;
+create policy progress_coach_select on storage.objects
+  for select using (
+    bucket_id = 'progress-photos'
+    and exists (
+      select 1 from profiles p
+      where p.id = auth.uid()
+        and p.role = 'coach'
+    )
+  );


### PR DESCRIPTION
## Summary
Backend half of epic #52. Mobile UI (ProgressTab, MeasurementLoggerSheet, photo grid, fl_chart) ships in a follow-up branch stacked on this one.

### Schema (3 migrations)
- \`00017_phase19_measurement_logs\` — weight + jsonb metrics + photo_url + note. RLS: trainee rw own; backend service-role. Constraint rejects empty-payload rows.
- \`00018_phase19_session_logs\` — 1:1 with bookings. jsonb feedback + coach_notes. RLS: trainee rw own (via booking join); coach rw all through service-role.
- \`00019_phase19_progress_photos_bucket\` — Supabase Storage bucket \`progress-photos\`; trainee writes \`<uid>/\` folder, coach reads all.

### Service layer
- \`ProgressStore\` interface + \`MockProgressStore\` + \`SupabaseProgressStore\`, wired into container.
- \`MeasurementValidationError\` w/ codes \`EMPTY_PAYLOAD\`, \`INVALID_WEIGHT\`.

### Routes
| Verb | Path | Auth |
|---|---|---|
| GET | \`/api/me/progress?days=&limit=\` | trainee active |
| POST | \`/api/me/measurement\` | trainee active |
| GET | \`/api/me/session-log/[bookingId]\` | trainee active + owns booking |
| POST | \`/api/me/session-log/[bookingId]\` | trainee active + owns booking (coachNotes silently dropped) |
| GET | \`/api/admin/trainees/[id]/progress?days=&limit=\` | coach |

## Test plan
- [x] Backend: 308/308 (was 272; +36 new across store unit + 4 route tests)
- [x] tsc clean, eslint clean

## Out of scope (next PR)
- Mobile ProgressTab + chart + photo timeline + MeasurementLoggerSheet
- CoachReadModel aggregates (last weight, trend direction)
- Post-session prompt deep-link from FCM (blocked on #36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)