### PR TITLE
feat: progress tracking mobile — ProgressScreen + MeasurementLoggerSheet (#52)

### DIFF
--- a/mobile/lib/features/progress/measurement_logger_sheet.dart
+++ b/mobile/lib/features/progress/measurement_logger_sheet.dart
@@ -1,0 +1,242 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../design/spacing.dart';
+import 'progress.dart';
+import 'progress_repository.dart';
+
+/// Bottom sheet for logging a measurement. All fields optional; nothing
+/// required. Empty submit shows a Hebrew "fill at least one" hint instead of
+/// firing a no-op POST (server would reject with EMPTY_PAYLOAD anyway).
+class MeasurementLoggerSheet extends ConsumerStatefulWidget {
+  const MeasurementLoggerSheet({super.key});
+
+  @override
+  ConsumerState<MeasurementLoggerSheet> createState() =>
+      _MeasurementLoggerSheetState();
+}
+
+class _MeasurementLoggerSheetState
+    extends ConsumerState<MeasurementLoggerSheet> {
+  final _weightController = TextEditingController();
+  final _noteController = TextEditingController();
+  int? _energy;
+  int? _soreness;
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    _weightController.dispose();
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  MeasurementInput _buildInput() {
+    final weightStr = _weightController.text.trim().replaceAll(',', '.');
+    final weight = weightStr.isEmpty ? null : double.tryParse(weightStr);
+    final metrics = <String, dynamic>{};
+    if (_energy != null) metrics['energy_1to5'] = _energy;
+    if (_soreness != null) metrics['soreness_1to5'] = _soreness;
+    return MeasurementInput(
+      weightKg: weight,
+      metrics: metrics.isEmpty ? null : metrics,
+      note: _noteController.text,
+    );
+  }
+
+  Future<void> _submit() async {
+    final input = _buildInput();
+    if (input.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('יש להזין לפחות שדה אחד')),
+      );
+      return;
+    }
+    setState(() => _submitting = true);
+    try {
+      await ref.read(progressRepositoryProvider).logMeasurement(input);
+      if (!mounted) return;
+      ref.invalidate(progressProvider);
+      Navigator.of(context).pop();
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('נשמר')),
+      );
+    } on MeasurementValidationFailure catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(e.message)));
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('שגיאת רשת — נסה שוב')),
+      );
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      key: const Key('measurement-logger-sheet'),
+      padding: EdgeInsets.only(
+        left: AppSpacing.lg,
+        right: AppSpacing.lg,
+        top: AppSpacing.lg,
+        bottom: MediaQuery.of(context).viewInsets.bottom + AppSpacing.lg,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'תיעוד התקדמות',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'כל השדות אופציונליים. גם רק משקל זה בסדר.',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          TextField(
+            key: const Key('weight-input'),
+            controller: _weightController,
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
+            ],
+            decoration: const InputDecoration(
+              labelText: 'משקל (ק"ג)',
+              hintText: 'לדוגמה: 72.5',
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          _RatingRow(
+            label: 'אנרגיה',
+            keyPrefix: 'energy',
+            value: _energy,
+            onChanged: (v) => setState(() => _energy = v),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          _RatingRow(
+            label: 'כאבי שרירים',
+            keyPrefix: 'soreness',
+            value: _soreness,
+            onChanged: (v) => setState(() => _soreness = v),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          TextField(
+            key: const Key('note-input'),
+            controller: _noteController,
+            minLines: 2,
+            maxLines: 4,
+            decoration: const InputDecoration(
+              labelText: 'הערה',
+              hintText: 'איך הרגשת? משהו ששווה לזכור?',
+            ),
+          ),
+          const SizedBox(height: AppSpacing.lg),
+          SizedBox(
+            width: double.infinity,
+            child: FilledButton(
+              key: const Key('measurement-submit'),
+              onPressed: _submitting ? null : _submit,
+              child: _submitting
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('שמור'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RatingRow extends StatelessWidget {
+  final String label;
+  final String keyPrefix;
+  final int? value;
+  final void Function(int?) onChanged;
+
+  const _RatingRow({
+    required this.label,
+    required this.keyPrefix,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Row(
+      children: [
+        SizedBox(
+          width: 110,
+          child: Text(label, style: Theme.of(context).textTheme.bodyMedium),
+        ),
+        Expanded(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              for (var i = 1; i <= 5; i++)
+                _RatingDot(
+                  key: Key('$keyPrefix-$i'),
+                  value: i,
+                  selected: value == i,
+                  color: scheme.primary,
+                  onTap: () => onChanged(value == i ? null : i),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RatingDot extends StatelessWidget {
+  final int value;
+  final bool selected;
+  final Color color;
+  final VoidCallback onTap;
+
+  const _RatingDot({
+    super.key,
+    required this.value,
+    required this.selected,
+    required this.color,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: selected ? color : Colors.transparent,
+          border: Border.all(color: color, width: 1.5),
+        ),
+        alignment: Alignment.center,
+        child: Text(
+          '$value',
+          style: TextStyle(
+            color: selected ? Colors.white : color,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/progress/progress.dart
+++ b/mobile/lib/features/progress/progress.dart
@@ -1,0 +1,68 @@
+class MeasurementLog {
+  final String id;
+  final String traineeId;
+  final DateTime loggedAt;
+  final double? weightKg;
+  final Map<String, dynamic>? metrics;
+  final String? photoUrl;
+  final String? note;
+
+  const MeasurementLog({
+    required this.id,
+    required this.traineeId,
+    required this.loggedAt,
+    this.weightKg,
+    this.metrics,
+    this.photoUrl,
+    this.note,
+  });
+
+  factory MeasurementLog.fromJson(Map<String, dynamic> json) => MeasurementLog(
+        id: json['id'] as String,
+        traineeId: json['traineeId'] as String,
+        loggedAt: DateTime.parse(json['loggedAt'] as String),
+        weightKg: (json['weightKg'] as num?)?.toDouble(),
+        metrics: json['metrics'] as Map<String, dynamic>?,
+        photoUrl: json['photoUrl'] as String?,
+        note: json['note'] as String?,
+      );
+}
+
+class ProgressView {
+  final List<MeasurementLog> measurements;
+  final MeasurementLog? lastMeasurement;
+
+  const ProgressView({required this.measurements, this.lastMeasurement});
+
+  factory ProgressView.fromJson(Map<String, dynamic> json) {
+    final list = (json['measurements'] as List? ?? [])
+        .cast<Map<String, dynamic>>()
+        .map(MeasurementLog.fromJson)
+        .toList();
+    final last = json['lastMeasurement'] as Map<String, dynamic>?;
+    return ProgressView(
+      measurements: list,
+      lastMeasurement: last != null ? MeasurementLog.fromJson(last) : null,
+    );
+  }
+}
+
+class MeasurementInput {
+  final double? weightKg;
+  final Map<String, dynamic>? metrics;
+  final String? photoUrl;
+  final String? note;
+
+  const MeasurementInput({this.weightKg, this.metrics, this.photoUrl, this.note});
+
+  Map<String, dynamic> toJson() {
+    final m = <String, dynamic>{};
+    if (weightKg != null) m['weightKg'] = weightKg;
+    if (metrics != null && metrics!.isNotEmpty) m['metrics'] = metrics;
+    if (photoUrl != null && photoUrl!.isNotEmpty) m['photoUrl'] = photoUrl;
+    if (note != null && note!.trim().isNotEmpty) m['note'] = note!.trim();
+    return m;
+  }
+
+  bool get isEmpty => toJson().isEmpty;
+}

--- a/mobile/lib/features/progress/progress_repository.dart
+++ b/mobile/lib/features/progress/progress_repository.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../utils/authed_http_client.dart';
+import 'progress.dart';
+
+abstract class ProgressRepository {
+  Future<ProgressView> fetch({int days = 90});
+  Future<MeasurementLog> logMeasurement(MeasurementInput input);
+}
+
+class HttpProgressRepository implements ProgressRepository {
+  final AuthedHttpClient _http;
+  HttpProgressRepository(this._http);
+
+  @override
+  Future<ProgressView> fetch({int days = 90}) async {
+    final json = await _http.get<Map<String, dynamic>>(
+      '/api/me/progress?days=$days',
+    );
+    return ProgressView.fromJson(json);
+  }
+
+  @override
+  Future<MeasurementLog> logMeasurement(MeasurementInput input) async {
+    if (input.isEmpty) {
+      throw const MeasurementValidationFailure(
+        'EMPTY_PAYLOAD',
+        'יש להזין לפחות שדה אחד',
+      );
+    }
+    try {
+      final json = await _http.post<Map<String, dynamic>>(
+        '/api/me/measurement',
+        data: input.toJson(),
+      );
+      return MeasurementLog.fromJson(
+        json['measurement'] as Map<String, dynamic>,
+      );
+    } on ApiException catch (e) {
+      // Surface validation errors as a typed failure so the UI can show
+      // a friendly Hebrew message rather than the raw server payload.
+      if (e.code == 'EMPTY_PAYLOAD') {
+        throw const MeasurementValidationFailure(
+          'EMPTY_PAYLOAD',
+          'יש להזין לפחות שדה אחד',
+        );
+      }
+      if (e.code == 'INVALID_WEIGHT') {
+        throw const MeasurementValidationFailure(
+          'INVALID_WEIGHT',
+          'משקל לא תקין',
+        );
+      }
+      rethrow;
+    }
+  }
+}
+
+class MeasurementValidationFailure implements Exception {
+  final String code;
+  final String message;
+  const MeasurementValidationFailure(this.code, this.message);
+}
+
+final progressRepositoryProvider = Provider<ProgressRepository>(
+  (ref) => HttpProgressRepository(ref.watch(authedHttpProvider)),
+);
+
+final progressProvider = FutureProvider<ProgressView>(
+  (ref) => ref.watch(progressRepositoryProvider).fetch(),
+);

--- a/mobile/lib/features/progress/progress_screen.dart
+++ b/mobile/lib/features/progress/progress_screen.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../design/spacing.dart';
+import '../../design/widgets.dart';
+import 'measurement_logger_sheet.dart';
+import 'progress.dart';
+import 'progress_repository.dart';
+import 'weight_chart.dart';
+
+class ProgressScreen extends ConsumerWidget {
+  const ProgressScreen({super.key});
+
+  Future<void> _openLogger(BuildContext context) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => const MeasurementLoggerSheet(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(progressProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('ההתקדמות שלי')),
+      floatingActionButton: FloatingActionButton.extended(
+        key: const Key('progress-log-fab'),
+        onPressed: () => _openLogger(context),
+        icon: const Icon(Icons.add),
+        label: const Text('תעד'),
+      ),
+      body: async.when(
+        loading: () => const Padding(
+          padding: EdgeInsets.all(AppSpacing.md),
+          child: SkeletonList(),
+        ),
+        error: (err, _) => Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: ErrorCard(
+            message: 'שגיאה בטעינת ההתקדמות',
+            onRetry: () => ref.invalidate(progressProvider),
+          ),
+        ),
+        data: (view) => RefreshIndicator(
+          onRefresh: () async => ref.refresh(progressProvider.future),
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.md,
+              AppSpacing.md,
+              AppSpacing.md,
+              80,
+            ),
+            children: [
+              _LastSnapshot(view: view),
+              const SizedBox(height: AppSpacing.lg),
+              const SectionHeader('משקל לאורך זמן'),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(AppSpacing.md),
+                  child: WeightChart(measurements: view.measurements),
+                ),
+              ),
+              const SizedBox(height: AppSpacing.lg),
+              const SectionHeader('יומן אחרון'),
+              if (view.measurements.isEmpty)
+                const EmptyState(
+                  icon: Icons.timeline,
+                  headline: 'עוד אין תיעודים',
+                  helper: 'כפתור התיעוד למטה — אפילו שורה אחת זה התחלה',
+                )
+              else
+                for (final m in view.measurements.take(20))
+                  _LogRow(key: Key('log-row-${m.id}'), log: m),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LastSnapshot extends StatelessWidget {
+  final ProgressView view;
+  const _LastSnapshot({required this.view});
+
+  @override
+  Widget build(BuildContext context) {
+    final last = view.lastMeasurement;
+    if (last == null) {
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Text(
+            'אין נתונים עדיין — תיעוד ראשון פותח גרף',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ),
+      );
+    }
+    final w = last.weightKg;
+    final delta = _weeklyDelta(view.measurements);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    w != null ? '${w.toStringAsFixed(1)} ק"ג' : '—',
+                    style: Theme.of(context).textTheme.displaySmall,
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    'מדידה אחרונה ${_relativeTime(last.loggedAt)}',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                  ),
+                ],
+              ),
+            ),
+            if (delta != null)
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.sm,
+                  vertical: AppSpacing.xs,
+                ),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(AppSpacing.radiusPill),
+                ),
+                child: Text(
+                  delta,
+                  style: Theme.of(context).textTheme.labelMedium,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static String? _weeklyDelta(List<MeasurementLog> ms) {
+    final withWeight = ms.where((m) => m.weightKg != null).toList();
+    if (withWeight.length < 2) return null;
+    final newest = withWeight.first;
+    final cutoff = newest.loggedAt.subtract(const Duration(days: 14));
+    final older = withWeight.firstWhere(
+      (m) => m.loggedAt.isBefore(cutoff) || m == withWeight.last,
+      orElse: () => withWeight.last,
+    );
+    if (older.id == newest.id) return null;
+    final diff = newest.weightKg! - older.weightKg!;
+    if (diff.abs() < 0.1) return '⟷ יציב';
+    final sign = diff > 0 ? '+' : '';
+    return '$sign${diff.toStringAsFixed(1)} ק"ג';
+  }
+
+  static String _relativeTime(DateTime t) {
+    final diff = DateTime.now().difference(t);
+    if (diff.inDays > 1) return 'לפני ${diff.inDays} ימים';
+    if (diff.inDays == 1) return 'אתמול';
+    if (diff.inHours >= 1) return 'לפני ${diff.inHours}ש׳';
+    return 'הרגע';
+  }
+}
+
+class _LogRow extends StatelessWidget {
+  final MeasurementLog log;
+  const _LogRow({super.key, required this.log});
+
+  @override
+  Widget build(BuildContext context) {
+    final parts = <String>[];
+    if (log.weightKg != null) {
+      parts.add('${log.weightKg!.toStringAsFixed(1)} ק"ג');
+    }
+    final metrics = log.metrics;
+    if (metrics != null) {
+      final e = metrics['energy_1to5'];
+      final s = metrics['soreness_1to5'];
+      if (e is num) parts.add('אנרגיה $e');
+      if (s is num) parts.add('כאב $s');
+    }
+    return Card(
+      child: ListTile(
+        title: Text(
+          parts.isEmpty ? (log.note ?? '—') : parts.join('  •  '),
+        ),
+        subtitle: log.note != null && parts.isNotEmpty
+            ? Text(
+                log.note!,
+                style: Theme.of(context).textTheme.bodySmall,
+              )
+            : null,
+        trailing: Text(
+          '${log.loggedAt.day}/${log.loggedAt.month}',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/progress/weight_chart.dart
+++ b/mobile/lib/features/progress/weight_chart.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+
+import '../../theme.dart';
+import 'progress.dart';
+
+/// Lightweight CustomPainter line chart for weight-over-time. Renders nothing
+/// when there are <2 weight points (caller decides what placeholder to show).
+class WeightChart extends StatelessWidget {
+  final List<MeasurementLog> measurements;
+  final double height;
+
+  const WeightChart({
+    super.key,
+    required this.measurements,
+    this.height = 180,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final points = measurements
+        .where((m) => m.weightKg != null)
+        .toList()
+        .reversed
+        .toList(); // chronological L→R
+    if (points.length < 2) {
+      return SizedBox(
+        height: height,
+        child: Center(
+          child: Text(
+            points.isEmpty
+                ? 'אין נתונים עדיין — תיעוד ראשון יראה גרף'
+                : 'נדרשים לפחות שני מדידות לגרף',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    return SizedBox(
+      key: const Key('weight-chart'),
+      height: height,
+      child: CustomPaint(
+        size: Size.infinite,
+        painter: _WeightChartPainter(
+          points: points,
+          line: BrandColors.teal,
+          fill: BrandColors.teal.withValues(alpha: 0.10),
+          axis: BrandColors.line,
+          label: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+}
+
+class _WeightChartPainter extends CustomPainter {
+  final List<MeasurementLog> points;
+  final Color line;
+  final Color fill;
+  final Color axis;
+  final Color label;
+
+  _WeightChartPainter({
+    required this.points,
+    required this.line,
+    required this.fill,
+    required this.axis,
+    required this.label,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final weights = points.map((p) => p.weightKg!).toList();
+    final minW = weights.reduce((a, b) => a < b ? a : b);
+    final maxW = weights.reduce((a, b) => a > b ? a : b);
+    // Pad the range so a flat trend still draws a band, and avoid /0.
+    final spread = (maxW - minW).abs();
+    final pad = spread < 0.5 ? 1.0 : spread * 0.15;
+    final lo = minW - pad;
+    final hi = maxW + pad;
+
+    final leftPad = 32.0;
+    final rightPad = 8.0;
+    final topPad = 8.0;
+    final bottomPad = 22.0;
+
+    final chartW = size.width - leftPad - rightPad;
+    final chartH = size.height - topPad - bottomPad;
+
+    // Axes
+    final axisPaint = Paint()
+      ..color = axis
+      ..strokeWidth = 1;
+    canvas.drawLine(
+      Offset(leftPad, topPad + chartH),
+      Offset(leftPad + chartW, topPad + chartH),
+      axisPaint,
+    );
+
+    // Plot points
+    final dx = chartW / (points.length - 1);
+    final offsets = <Offset>[];
+    for (var i = 0; i < points.length; i++) {
+      final w = points[i].weightKg!;
+      final t = (w - lo) / (hi - lo);
+      final y = topPad + chartH - t * chartH;
+      offsets.add(Offset(leftPad + i * dx, y));
+    }
+
+    // Fill under the line
+    final fillPath = Path()
+      ..moveTo(offsets.first.dx, topPad + chartH)
+      ..lineTo(offsets.first.dx, offsets.first.dy);
+    for (var i = 1; i < offsets.length; i++) {
+      fillPath.lineTo(offsets[i].dx, offsets[i].dy);
+    }
+    fillPath.lineTo(offsets.last.dx, topPad + chartH);
+    fillPath.close();
+    canvas.drawPath(fillPath, Paint()..color = fill);
+
+    // Line
+    final linePaint = Paint()
+      ..color = line
+      ..strokeWidth = 2.5
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+    final linePath = Path()..moveTo(offsets.first.dx, offsets.first.dy);
+    for (var i = 1; i < offsets.length; i++) {
+      linePath.lineTo(offsets[i].dx, offsets[i].dy);
+    }
+    canvas.drawPath(linePath, linePaint);
+
+    // Dots
+    final dotPaint = Paint()..color = line;
+    for (final o in offsets) {
+      canvas.drawCircle(o, 3.5, dotPaint);
+    }
+
+    // Y labels (min + max)
+    _drawText(canvas, hi.toStringAsFixed(1), Offset(0, topPad - 4));
+    _drawText(
+      canvas,
+      lo.toStringAsFixed(1),
+      Offset(0, topPad + chartH - 8),
+    );
+
+    // X labels (first + last date as DD/MM)
+    _drawText(
+      canvas,
+      _fmt(points.first.loggedAt),
+      Offset(leftPad - 12, topPad + chartH + 6),
+    );
+    _drawText(
+      canvas,
+      _fmt(points.last.loggedAt),
+      Offset(leftPad + chartW - 22, topPad + chartH + 6),
+    );
+  }
+
+  void _drawText(Canvas canvas, String text, Offset pos) {
+    final tp = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: TextStyle(color: label, fontSize: 10),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    tp.paint(canvas, pos);
+  }
+
+  String _fmt(DateTime d) =>
+      '${d.day.toString().padLeft(2, '0')}/${d.month.toString().padLeft(2, '0')}';
+
+  @override
+  bool shouldRepaint(covariant _WeightChartPainter old) =>
+      old.points != points || old.line != line || old.fill != fill;
+}

--- a/mobile/lib/features/slots/home_screen.dart
+++ b/mobile/lib/features/slots/home_screen.dart
@@ -14,6 +14,7 @@ import '../dashboard/dashboard_repository.dart';
 import '../history/history_screen.dart';
 import '../profile/profile_repository.dart';
 import '../profile/profile_screen.dart';
+import '../progress/progress_screen.dart';
 import 'slot.dart';
 import 'slot_repository.dart';
 
@@ -317,6 +318,14 @@ class _QuickActions extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Row(
       children: [
+        _QuickActionChip(
+          icon: Icons.timeline,
+          label: 'התקדמות',
+          onTap: () => Navigator.of(context).push(
+            MaterialPageRoute(builder: (_) => const ProgressScreen()),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.sm),
         _QuickActionChip(
           icon: Icons.person_outline,
           label: 'הפרופיל',

--- a/mobile/test/features/progress/measurement_logger_sheet_test.dart
+++ b/mobile/test/features/progress/measurement_logger_sheet_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:velofit/features/progress/measurement_logger_sheet.dart';
+import 'package:velofit/features/progress/progress.dart';
+import 'package:velofit/features/progress/progress_repository.dart';
+
+class _FakeProgressRepo extends Mock implements ProgressRepository {}
+
+Widget _harness(ProgressRepository repo) {
+  return ProviderScope(
+    overrides: [progressRepositoryProvider.overrideWithValue(repo)],
+    child: MaterialApp(
+      builder: (_, child) => Directionality(
+        textDirection: TextDirection.rtl,
+        child: child ?? const SizedBox.shrink(),
+      ),
+      home: const Scaffold(body: MeasurementLoggerSheet()),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(const MeasurementInput());
+  });
+
+  group('MeasurementLoggerSheet', () {
+    testWidgets('empty submit shows hint, does not call repo', (tester) async {
+      final repo = _FakeProgressRepo();
+      await tester.pumpWidget(_harness(repo));
+
+      await tester.tap(find.byKey(const Key('measurement-submit')));
+      await tester.pump();
+
+      expect(find.text('יש להזין לפחות שדה אחד'), findsOneWidget);
+      verifyNever(() => repo.logMeasurement(any()));
+    });
+
+    testWidgets('submits weight via parsed number', (tester) async {
+      final repo = _FakeProgressRepo();
+      when(() => repo.logMeasurement(any())).thenAnswer((inv) async {
+        final input = inv.positionalArguments.first as MeasurementInput;
+        return MeasurementLog(
+          id: 'm1',
+          traineeId: 't1',
+          loggedAt: DateTime.now(),
+          weightKg: input.weightKg,
+        );
+      });
+      await tester.pumpWidget(_harness(repo));
+
+      await tester.enterText(find.byKey(const Key('weight-input')), '72.5');
+      await tester.tap(find.byKey(const Key('measurement-submit')));
+      await tester.pump();
+
+      final captured = verify(() => repo.logMeasurement(captureAny()))
+          .captured
+          .single as MeasurementInput;
+      expect(captured.weightKg, 72.5);
+    });
+
+    testWidgets('accepts comma as decimal separator', (tester) async {
+      final repo = _FakeProgressRepo();
+      when(() => repo.logMeasurement(any())).thenAnswer((_) async =>
+          MeasurementLog(
+            id: 'm1',
+            traineeId: 't1',
+            loggedAt: DateTime.now(),
+            weightKg: 72.5,
+          ));
+      await tester.pumpWidget(_harness(repo));
+
+      await tester.enterText(find.byKey(const Key('weight-input')), '72,5');
+      await tester.tap(find.byKey(const Key('measurement-submit')));
+      await tester.pump();
+
+      final captured = verify(() => repo.logMeasurement(captureAny()))
+          .captured
+          .single as MeasurementInput;
+      expect(captured.weightKg, 72.5);
+    });
+
+    testWidgets('energy + soreness rating goes into metrics', (tester) async {
+      final repo = _FakeProgressRepo();
+      when(() => repo.logMeasurement(any())).thenAnswer((_) async =>
+          MeasurementLog(
+            id: 'm1',
+            traineeId: 't1',
+            loggedAt: DateTime.now(),
+            metrics: const {'energy_1to5': 4, 'soreness_1to5': 2},
+          ));
+      await tester.pumpWidget(_harness(repo));
+
+      await tester.tap(find.byKey(const Key('energy-4')));
+      await tester.tap(find.byKey(const Key('soreness-2')));
+      await tester.tap(find.byKey(const Key('measurement-submit')));
+      await tester.pump();
+
+      final captured = verify(() => repo.logMeasurement(captureAny()))
+          .captured
+          .single as MeasurementInput;
+      expect(captured.metrics, {'energy_1to5': 4, 'soreness_1to5': 2});
+    });
+
+    testWidgets('shows server validation error in Hebrew', (tester) async {
+      final repo = _FakeProgressRepo();
+      when(() => repo.logMeasurement(any())).thenThrow(
+        const MeasurementValidationFailure('INVALID_WEIGHT', 'משקל לא תקין'),
+      );
+      await tester.pumpWidget(_harness(repo));
+
+      await tester.enterText(find.byKey(const Key('weight-input')), '600');
+      await tester.tap(find.byKey(const Key('measurement-submit')));
+      await tester.pump();
+
+      expect(find.text('משקל לא תקין'), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/features/progress/progress_screen_test.dart
+++ b/mobile/test/features/progress/progress_screen_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:velofit/features/progress/progress.dart';
+import 'package:velofit/features/progress/progress_repository.dart';
+import 'package:velofit/features/progress/progress_screen.dart';
+
+class _FakeProgressRepo extends Mock implements ProgressRepository {}
+
+Widget _harness(ProgressRepository repo) {
+  return ProviderScope(
+    overrides: [progressRepositoryProvider.overrideWithValue(repo)],
+    child: MaterialApp(
+      builder: (_, child) => Directionality(
+        textDirection: TextDirection.rtl,
+        child: child ?? const SizedBox.shrink(),
+      ),
+      home: const ProgressScreen(),
+    ),
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(const MeasurementInput());
+  });
+
+  group('ProgressScreen', () {
+    testWidgets('renders empty state when no measurements', (tester) async {
+      final repo = _FakeProgressRepo();
+      when(() => repo.fetch(days: any(named: 'days'))).thenAnswer(
+        (_) async => const ProgressView(measurements: [], lastMeasurement: null),
+      );
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.text('עוד אין תיעודים'), findsOneWidget);
+      expect(find.byKey(const Key('progress-log-fab')), findsOneWidget);
+    });
+
+    testWidgets('renders last snapshot + chart when 2+ measurements', (tester) async {
+      final repo = _FakeProgressRepo();
+      final m1 = MeasurementLog(
+        id: 'm1',
+        traineeId: 't1',
+        loggedAt: DateTime(2026, 5, 1),
+        weightKg: 73.0,
+      );
+      final m2 = MeasurementLog(
+        id: 'm2',
+        traineeId: 't1',
+        loggedAt: DateTime(2026, 5, 20),
+        weightKg: 71.5,
+      );
+      when(() => repo.fetch(days: any(named: 'days'))).thenAnswer(
+        (_) async => ProgressView(
+          measurements: [m2, m1], // newest first
+          lastMeasurement: m2,
+        ),
+      );
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      // 71.5 appears in both the snapshot card AND the log row list — both valid
+      expect(find.text('71.5 ק"ג'), findsAtLeast(1));
+      expect(find.byKey(const Key('weight-chart')), findsOneWidget);
+      expect(find.byKey(const Key('log-row-m1')), findsOneWidget);
+      expect(find.byKey(const Key('log-row-m2')), findsOneWidget);
+    });
+
+    testWidgets('chart placeholder shows when only one weight point',
+        (tester) async {
+      final repo = _FakeProgressRepo();
+      final m1 = MeasurementLog(
+        id: 'm1',
+        traineeId: 't1',
+        loggedAt: DateTime(2026, 5, 1),
+        weightKg: 73.0,
+      );
+      when(() => repo.fetch(days: any(named: 'days'))).thenAnswer(
+        (_) async => ProgressView(measurements: [m1], lastMeasurement: m1),
+      );
+
+      await tester.pumpWidget(_harness(repo));
+      await tester.pumpAndSettle();
+
+      expect(find.text('נדרשים לפחות שני מדידות לגרף'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Mobile half of epic #52. Sits on the backend PR #59 schema + APIs.

### Shipped
- \`ProgressScreen\` — last-weight snapshot card + weekly-delta chip + custom-painted line chart + newest-first log list. Pull-to-refresh + ErrorCard with retry.
- \`MeasurementLoggerSheet\` — bottom sheet w/ optional weight (accepts comma decimals), energy + soreness 1-5 rating dots, free-text note. Empty submit shows Hebrew hint instead of POSTing.
- \`WeightChart\` — hand-rolled CustomPainter, no fl_chart dep. Renders when ≥2 weight points; placeholder copy otherwise.
- Quick-action chip on trainee home (\`Icons.timeline\`, 'התקדמות').
- Surfaces server EMPTY_PAYLOAD / INVALID_WEIGHT as typed \`MeasurementValidationFailure\` with Hebrew message.

### Out of scope (next PR or follow-up issues)
- Photo upload + photo timeline — requires \`image_picker\` native plumbing (iOS Info.plist + Android manifest). Bucket policies already shipped in #59.
- Post-session deep-link entry from FCM — blocked on #36.
- Coach progress view (uses /api/admin/trainees/:id/progress). Endpoint shipped; UI not wired yet.
- CoachReadModel aggregates surface in trainee detail.

## Test plan
- [x] \`flutter analyze\` clean
- [x] \`flutter test\` → 117/117 (was 109; +8 new progress tests)
- [x] Backend untouched, vitest 308/308

🤖 Generated with [Claude Code](https://claude.com/claude-code)