### PR TITLE
feat: coach progress visibility — aggregates + detail card + list chips (#62)

### DIFF
--- a/mobile/lib/features/coach/admin_repository.dart
+++ b/mobile/lib/features/coach/admin_repository.dart
@@ -44,6 +44,11 @@ class TraineeRecord {
   final bool isRecurring;
   final int? preferredDay;
   final String? preferredTime;
+  // Progress aggregates (#62) — null when the trainee hasn't logged / attended.
+  final double? lastWeightKg;
+  final String? weightTrend14d; // 'up' | 'flat' | 'down'
+  final DateTime? lastMeasurementAt;
+  final double? attendanceRate; // 0..1
 
   const TraineeRecord({
     required this.id,
@@ -53,6 +58,10 @@ class TraineeRecord {
     this.email,
     this.preferredDay,
     this.preferredTime,
+    this.lastWeightKg,
+    this.weightTrend14d,
+    this.lastMeasurementAt,
+    this.attendanceRate,
   });
 
   factory TraineeRecord.fromJson(Map<String, dynamic> json) => TraineeRecord(
@@ -64,6 +73,12 @@ class TraineeRecord {
         isRecurring: json['isRecurring'] as bool? ?? false,
         preferredDay: json['preferredDay'] as int?,
         preferredTime: json['preferredTime'] as String?,
+        lastWeightKg: (json['lastWeightKg'] as num?)?.toDouble(),
+        weightTrend14d: json['weightTrend14d'] as String?,
+        lastMeasurementAt: json['lastMeasurementAt'] == null
+            ? null
+            : DateTime.parse(json['lastMeasurementAt'] as String),
+        attendanceRate: (json['attendanceRate'] as num?)?.toDouble(),
       );
 }
 

--- a/mobile/lib/features/coach/coach_progress_repository.dart
+++ b/mobile/lib/features/coach/coach_progress_repository.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../utils/authed_http_client.dart';
+import '../progress/progress.dart';
+
+/// Coach-side read of a trainee's progress. Hits the existing admin endpoint
+/// (GET /api/admin/trainees/:id/progress) and reuses the trainee-side
+/// ProgressView/MeasurementLog models + WeightChart widget.
+abstract class CoachProgressRepository {
+  Future<ProgressView> fetch(String traineeId);
+}
+
+class HttpCoachProgressRepository implements CoachProgressRepository {
+  final AuthedHttpClient _http;
+  HttpCoachProgressRepository(this._http);
+
+  @override
+  Future<ProgressView> fetch(String traineeId) async {
+    final json = await _http.get<Map<String, dynamic>>(
+      '/api/admin/trainees/$traineeId/progress',
+    );
+    return ProgressView.fromJson(json);
+  }
+}
+
+final coachProgressRepositoryProvider = Provider<CoachProgressRepository>(
+  (ref) => HttpCoachProgressRepository(ref.watch(authedHttpProvider)),
+);
+
+final coachProgressProvider = FutureProvider.family<ProgressView, String>(
+  (ref, traineeId) => ref.watch(coachProgressRepositoryProvider).fetch(traineeId),
+);

--- a/mobile/lib/features/coach/coach_trainee_detail_screen.dart
+++ b/mobile/lib/features/coach/coach_trainee_detail_screen.dart
@@ -4,6 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../design/spacing.dart';
 import '../../design/widgets.dart';
 import '../../theme.dart';
+import '../progress/progress.dart';
+import '../progress/weight_chart.dart';
+import 'coach_progress_repository.dart';
 import 'notes_sheet.dart';
 import 'trainee_detail_repository.dart';
 
@@ -40,6 +43,8 @@ class CoachTraineeDetailScreen extends ConsumerWidget {
             _BioCard(bio: v.bio),
             const SizedBox(height: AppSpacing.lg),
             _SessionsCard(sessions: v.sessions),
+            const SizedBox(height: AppSpacing.lg),
+            _ProgressCard(traineeId: v.id),
             const SizedBox(height: AppSpacing.lg),
             FilledButton.tonalIcon(
               key: const Key('open-notes-button'),
@@ -288,6 +293,100 @@ class _SessionRow extends StatelessWidget {
           Text(
             '$day.$mon',
             style: Theme.of(context).textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProgressCard extends ConsumerWidget {
+  final String traineeId;
+  const _ProgressCard({required this.traineeId});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(coachProgressProvider(traineeId));
+    return Container(
+      decoration: BoxDecoration(
+        color: BrandColors.surface,
+        borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
+        border: Border.all(color: BrandColors.line),
+      ),
+      padding: const EdgeInsets.all(AppSpacing.md),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SectionHeader('התקדמות'),
+          async.when(
+            loading: () => const SkeletonList(count: 2),
+            error: (_, _) => ErrorCard(
+              key: const Key('progress-error'),
+              message: 'שגיאה בטעינת ההתקדמות',
+              onRetry: () => ref.invalidate(coachProgressProvider(traineeId)),
+            ),
+            data: (view) {
+              if (view.measurements.isEmpty) {
+                return const EmptyState(
+                  key: Key('progress-empty'),
+                  icon: Icons.monitor_weight_outlined,
+                  headline: 'אין מדידות עדיין',
+                  helper: 'מדידות משקל של המתאמן יופיעו כאן',
+                );
+              }
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  WeightChart(measurements: view.measurements, height: 160),
+                  const SizedBox(height: AppSpacing.sm),
+                  for (final m in view.measurements.take(5))
+                    _MeasurementRow(log: m),
+                ],
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MeasurementRow extends StatelessWidget {
+  final MeasurementLog log;
+  const _MeasurementRow({required this.log});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final w = log.weightKg;
+    final label = w != null
+        ? '${w.toStringAsFixed(1)} ק״ג'
+        : (log.note?.isNotEmpty == true ? log.note! : 'מדידה');
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      child: Row(
+        children: [
+          Container(
+            width: 4,
+            height: 18,
+            decoration: BoxDecoration(
+              color: BrandColors.teal,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: Text(
+              label,
+              style: theme.textTheme.titleSmall?.copyWith(
+                color: BrandColors.ink,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          Text(
+            '${log.loggedAt.day}.${log.loggedAt.month}',
+            style: theme.textTheme.bodySmall,
           ),
         ],
       ),

--- a/mobile/lib/features/coach/coach_trainees_screen.dart
+++ b/mobile/lib/features/coach/coach_trainees_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../design/spacing.dart';
 import '../../design/widgets.dart';
+import '../../theme.dart';
 import 'admin_repository.dart';
 import 'coach_trainee_detail_screen.dart';
 import 'notes_sheet.dart';
@@ -142,6 +143,7 @@ class _TraineeRow extends ConsumerWidget {
                 if (trainee.email != null)
                   Text(trainee.email!,
                       style: Theme.of(context).textTheme.bodySmall),
+                _ProgressChips(trainee: trainee),
               ],
             ),
           ),
@@ -192,6 +194,103 @@ class _TraineeRow extends ConsumerWidget {
             ),
         ],
         ),
+      ),
+    );
+  }
+}
+
+/// At-a-glance progress signals for a trainee row (#62): last weight + 14d
+/// trend arrow (teal, primary), and attendance % (muted, secondary). Each chip
+/// hides when its datum is absent, so never-logged / never-attended trainees
+/// show a clean row rather than a misleading placeholder.
+class _ProgressChips extends StatelessWidget {
+  final TraineeRecord trainee;
+  const _ProgressChips({required this.trainee});
+
+  @override
+  Widget build(BuildContext context) {
+    final showWeight = trainee.lastWeightKg != null;
+    final showAttendance = trainee.attendanceRate != null;
+    if (!showWeight && !showAttendance) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (showWeight) ...[
+            _Chip(
+              key: Key('weight-chip-${trainee.id}'),
+              icon: _trendIcon(trainee.weightTrend14d),
+              label: '${trainee.lastWeightKg!.toStringAsFixed(1)} ק״ג',
+              color: BrandColors.teal,
+              bg: BrandColors.teal.withValues(alpha: 0.10),
+            ),
+            const SizedBox(width: AppSpacing.xs),
+          ],
+          if (showAttendance)
+            _Chip(
+              key: Key('attendance-chip-${trainee.id}'),
+              icon: Icons.event_available,
+              label: '${(trainee.attendanceRate! * 100).round()}%',
+              color: BrandColors.inkMuted,
+              bg: Colors.transparent,
+            ),
+        ],
+      ),
+    );
+  }
+
+  static IconData? _trendIcon(String? trend) {
+    switch (trend) {
+      case 'up':
+        return Icons.north_east;
+      case 'down':
+        return Icons.south_east;
+      case 'flat':
+        return Icons.east;
+      default:
+        return null;
+    }
+  }
+}
+
+class _Chip extends StatelessWidget {
+  final IconData? icon;
+  final String label;
+  final Color color;
+  final Color bg;
+  const _Chip({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.bg,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (icon != null) ...[
+            Icon(icon, size: 13, color: color),
+            const SizedBox(width: 2),
+          ],
+          Text(
+            label,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: color,
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/test/features/coach/coach_progress_card_test.dart
+++ b/mobile/test/features/coach/coach_progress_card_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:velofit/features/coach/coach_progress_repository.dart';
+import 'package:velofit/features/coach/coach_trainee_detail_screen.dart';
+import 'package:velofit/features/coach/trainee_detail_repository.dart';
+import 'package:velofit/features/progress/progress.dart';
+
+class _FakeDetailRepo extends Mock implements TraineeDetailRepository {}
+
+class _FakeCoachProgressRepo extends Mock implements CoachProgressRepository {}
+
+MeasurementLog _m(double? w, DateTime at, {String? note}) =>
+    MeasurementLog(id: 'm${at.day}', traineeId: 't1', loggedAt: at, weightKg: w, note: note);
+
+Widget _harness(CoachProgressRepository progress) {
+  final detail = _FakeDetailRepo();
+  when(() => detail.fetch('t1')).thenAnswer((_) async => const TraineeDetailView(
+        id: 't1',
+        name: 'יעל כהן',
+        isActive: true,
+        bio: TraineeBio(),
+        sessions: [],
+        weekBookingsCount: 0,
+      ));
+  return ProviderScope(
+    overrides: [
+      traineeDetailRepositoryProvider.overrideWithValue(detail),
+      coachProgressRepositoryProvider.overrideWithValue(progress),
+    ],
+    child: MaterialApp(
+      builder: (context, child) => Directionality(
+        textDirection: TextDirection.rtl,
+        child: child ?? const SizedBox.shrink(),
+      ),
+      home: const CoachTraineeDetailScreen(traineeId: 't1'),
+    ),
+  );
+}
+
+/// Tall viewport so the whole detail ListView (progress card is last) lays out
+/// — otherwise the lazy ListView never builds the off-screen card.
+Future<void> _pump(WidgetTester tester, Widget w) async {
+  tester.view.physicalSize = const Size(1200, 3200);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(w);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  group('CoachTraineeDetailScreen progress card', () {
+    testWidgets('renders SectionHeader + chart + weight rows when measurements exist',
+        (tester) async {
+      final repo = _FakeCoachProgressRepo();
+      final newest = _m(68.0, DateTime(2026, 5, 20));
+      when(() => repo.fetch('t1')).thenAnswer((_) async => ProgressView(
+            measurements: [newest, _m(70.0, DateTime(2026, 5, 1))],
+            lastMeasurement: newest,
+          ));
+
+      await _pump(tester, _harness(repo));
+
+      expect(find.text('התקדמות'), findsOneWidget);
+      expect(find.byKey(const Key('weight-chart')), findsOneWidget);
+      expect(find.text('68.0 ק״ג'), findsOneWidget);
+    });
+
+    testWidgets('shows progress-empty EmptyState when no measurements', (tester) async {
+      final repo = _FakeCoachProgressRepo();
+      when(() => repo.fetch('t1'))
+          .thenAnswer((_) async => const ProgressView(measurements: []));
+
+      await _pump(tester, _harness(repo));
+
+      expect(find.byKey(const Key('progress-empty')), findsOneWidget);
+      expect(find.text('אין מדידות עדיין'), findsOneWidget);
+    });
+
+    testWidgets('shows chart placeholder when only one weight point', (tester) async {
+      final repo = _FakeCoachProgressRepo();
+      when(() => repo.fetch('t1')).thenAnswer((_) async =>
+          ProgressView(measurements: [_m(70.0, DateTime(2026, 5, 20))]));
+
+      await _pump(tester, _harness(repo));
+
+      // <2 weight points → WeightChart renders its placeholder, not the chart.
+      expect(find.byKey(const Key('weight-chart')), findsNothing);
+      expect(find.text('נדרשים לפחות שני מדידות לגרף'), findsOneWidget);
+    });
+
+    testWidgets('error path shows progress-error', (tester) async {
+      final repo = _FakeCoachProgressRepo();
+      when(() => repo.fetch('t1')).thenThrow(Exception('boom'));
+
+      await _pump(tester, _harness(repo));
+
+      expect(find.byKey(const Key('progress-error')), findsOneWidget);
+    });
+  });
+}

--- a/mobile/test/features/coach/coach_trainee_detail_screen_test.dart
+++ b/mobile/test/features/coach/coach_trainee_detail_screen_test.dart
@@ -3,13 +3,25 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
+import 'package:velofit/features/coach/coach_progress_repository.dart';
 import 'package:velofit/features/coach/coach_trainee_detail_screen.dart';
 import 'package:velofit/features/coach/trainee_detail_repository.dart';
+import 'package:velofit/features/progress/progress.dart';
 
 class _FakeRepo extends Mock implements TraineeDetailRepository {}
 
-Widget _harness(TraineeDetailRepository repo) => ProviderScope(
-      overrides: [traineeDetailRepositoryProvider.overrideWithValue(repo)],
+class _FakeCoachProgressRepo extends Mock implements CoachProgressRepository {}
+
+Widget _harness(TraineeDetailRepository repo) {
+  final progress = _FakeCoachProgressRepo();
+  when(() => progress.fetch(any())).thenAnswer(
+    (_) async => const ProgressView(measurements: []),
+  );
+  return ProviderScope(
+      overrides: [
+        traineeDetailRepositoryProvider.overrideWithValue(repo),
+        coachProgressRepositoryProvider.overrideWithValue(progress),
+      ],
       child: MaterialApp(
         builder: (context, child) => Directionality(
           textDirection: TextDirection.rtl,
@@ -18,6 +30,7 @@ Widget _harness(TraineeDetailRepository repo) => ProviderScope(
         home: const CoachTraineeDetailScreen(traineeId: 't1'),
       ),
     );
+}
 
 TraineeDetailView _viewWith({TraineeBio? bio, List<TraineeSession>? sessions, bool active = true}) =>
     TraineeDetailView(

--- a/mobile/test/features/coach/coach_trainees_screen_test.dart
+++ b/mobile/test/features/coach/coach_trainees_screen_test.dart
@@ -63,6 +63,78 @@ void main() {
       expect(find.byKey(const Key('deactivate-t3')), findsNothing);
     });
 
+    testWidgets('shows weight chip with trend arrow + attendance chip', (tester) async {
+      final admin = _FakeAdminRepo();
+      when(() => admin.listTrainees()).thenAnswer((_) async => [
+            const TraineeRecord(
+              id: 't1',
+              name: 'יעל כהן',
+              status: 'active',
+              isRecurring: false,
+              lastWeightKg: 68.0,
+              weightTrend14d: 'down',
+              attendanceRate: 0.8,
+            ),
+          ]);
+
+      await tester.pumpWidget(_harness(admin: admin));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('weight-chip-t1')), findsOneWidget);
+      expect(
+        find.descendant(
+          of: find.byKey(const Key('weight-chip-t1')),
+          matching: find.byIcon(Icons.south_east),
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('68.0 ק״ג'), findsOneWidget);
+      expect(find.byKey(const Key('attendance-chip-t1')), findsOneWidget);
+      expect(find.text('80%'), findsOneWidget);
+    });
+
+    testWidgets('weight chip uses up/flat arrows per trend', (tester) async {
+      final admin = _FakeAdminRepo();
+      when(() => admin.listTrainees()).thenAnswer((_) async => [
+            const TraineeRecord(
+                id: 't1', name: 'A', status: 'active', isRecurring: false,
+                lastWeightKg: 70, weightTrend14d: 'up'),
+            const TraineeRecord(
+                id: 't2', name: 'B', status: 'active', isRecurring: false,
+                lastWeightKg: 70, weightTrend14d: 'flat'),
+          ]);
+
+      await tester.pumpWidget(_harness(admin: admin));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.descendant(
+            of: find.byKey(const Key('weight-chip-t1')),
+            matching: find.byIcon(Icons.north_east)),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+            of: find.byKey(const Key('weight-chip-t2')),
+            matching: find.byIcon(Icons.east)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('chips hidden when aggregates are null', (tester) async {
+      final admin = _FakeAdminRepo();
+      when(() => admin.listTrainees()).thenAnswer((_) async => [
+            const TraineeRecord(
+                id: 't1', name: 'יעל', status: 'active', isRecurring: false),
+          ]);
+
+      await tester.pumpWidget(_harness(admin: admin));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('weight-chip-t1')), findsNothing);
+      expect(find.byKey(const Key('attendance-chip-t1')), findsNothing);
+    });
+
     testWidgets('invite form submits email + name', (tester) async {
       final admin = _FakeAdminRepo();
       when(() => admin.listTrainees()).thenAnswer((_) async => []);

--- a/src/app/api/admin/trainees/route.ts
+++ b/src/app/api/admin/trainees/route.ts
@@ -29,6 +29,10 @@ export async function GET(request: NextRequest) {
       preferredTime: s.preferredTime,
       isActive: s.status !== "deactivated" && s.status !== "rejected",
       status: s.status,
+      lastWeightKg: s.lastWeightKg,
+      weightTrend14d: s.weightTrend14d,
+      lastMeasurementAt: s.lastMeasurementAt,
+      attendanceRate: s.attendanceRate,
     })),
   });
 }

--- a/src/lib/coach/__tests__/read-model.test.ts
+++ b/src/lib/coach/__tests__/read-model.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { MockBookingStore } from "@/lib/services/booking-store";
 import { makeBookings } from "@/lib/services/bookings";
 import { MockAuthService } from "@/lib/supabase/auth-service";
+import { MockProgressStore } from "@/lib/services/progress-store";
 import { makeCoachReadModel } from "../mock-read-model";
 import { Profile } from "@/lib/types";
 
@@ -20,13 +21,15 @@ describe("CoachReadModel", () => {
   let store: MockBookingStore;
   let auth: MockAuthService;
   let bookings: ReturnType<typeof makeBookings>;
+  let progress: MockProgressStore;
   let coachRead: ReturnType<typeof makeCoachReadModel>;
 
   beforeEach(() => {
     store = new MockBookingStore();
     auth = new MockAuthService();
     bookings = makeBookings(store, null, null);
-    coachRead = makeCoachReadModel(store, auth, bookings);
+    progress = new MockProgressStore();
+    coachRead = makeCoachReadModel(store, auth, bookings, progress);
 
     vi.setSystemTime(new Date("2026-04-06T08:00:00Z"));
     auth._seedTrainee({ ...trainee, id: "t1", name: "Yael" });
@@ -83,6 +86,82 @@ describe("CoachReadModel", () => {
     });
   });
 
+  describe("getTraineesList — progress aggregates", () => {
+    const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000);
+    const get = async (id: string) =>
+      (await coachRead.getTraineesList()).find((t) => t.id === id)!;
+
+    it("reports weightTrend14d 'down' + lastWeightKg when newest is >=0.5kg below a >=14d-older point", async () => {
+      await progress.createMeasurement("t1", { weightKg: 70, loggedAt: daysAgo(20) });
+      await progress.createMeasurement("t1", { weightKg: 68, loggedAt: daysAgo(1) });
+
+      const t1 = await get("t1");
+      expect(t1.weightTrend14d).toBe("down");
+      expect(t1.lastWeightKg).toBe(68);
+    });
+
+    it("reports weightTrend14d 'up' when newest is >=0.5kg above a >=14d-older point", async () => {
+      await progress.createMeasurement("t1", { weightKg: 68, loggedAt: daysAgo(20) });
+      await progress.createMeasurement("t1", { weightKg: 70, loggedAt: daysAgo(1) });
+
+      expect((await get("t1")).weightTrend14d).toBe("up");
+    });
+
+    it("reports weightTrend14d 'flat' when |delta| < 0.5kg", async () => {
+      await progress.createMeasurement("t1", { weightKg: 70.0, loggedAt: daysAgo(20) });
+      await progress.createMeasurement("t1", { weightKg: 70.3, loggedAt: daysAgo(1) });
+
+      expect((await get("t1")).weightTrend14d).toBe("flat");
+    });
+
+    it("reports null trend with a single weight point (lastWeightKg still set)", async () => {
+      await progress.createMeasurement("t1", { weightKg: 70, loggedAt: daysAgo(1) });
+
+      const t1 = await get("t1");
+      expect(t1.weightTrend14d).toBeNull();
+      expect(t1.lastWeightKg).toBe(70);
+    });
+
+    it("reports null trend when no point is >=14d older than the newest", async () => {
+      await progress.createMeasurement("t1", { weightKg: 70, loggedAt: daysAgo(5) });
+      await progress.createMeasurement("t1", { weightKg: 71, loggedAt: daysAgo(1) });
+
+      const t1 = await get("t1");
+      expect(t1.weightTrend14d).toBeNull();
+      expect(t1.lastWeightKg).toBe(71);
+    });
+
+    it("lastMeasurementAt reflects the newest measurement even when its weight is null", async () => {
+      await progress.createMeasurement("t1", { weightKg: 70, loggedAt: daysAgo(20) });
+      const noteOnly = daysAgo(1);
+      await progress.createMeasurement("t1", { note: "felt good", loggedAt: noteOnly });
+
+      const t1 = await get("t1");
+      expect(t1.lastWeightKg).toBe(70);
+      expect(t1.lastMeasurementAt).toBe(noteOnly.toISOString());
+    });
+
+    it("reports null aggregates for a trainee with no measurements", async () => {
+      const t2 = await get("t2");
+      expect(t2.lastWeightKg).toBeNull();
+      expect(t2.weightTrend14d).toBeNull();
+      expect(t2.lastMeasurementAt).toBeNull();
+    });
+
+    it("attendanceRate is null with no past bookings", async () => {
+      expect((await get("t1")).attendanceRate).toBeNull();
+    });
+
+    it("attendanceRate is 1.0 for a past confirmed booking", async () => {
+      // slot-a is at 2026-04-06 10:00 IL; advance the clock past it.
+      await bookings.book("t1", "slot-a", { bypass: true });
+      vi.setSystemTime(new Date("2026-04-07T08:00:00Z"));
+
+      expect((await get("t1")).attendanceRate).toBe(1);
+      // no_show path stays untestable until Phase 16 wires the terminal state.
+    });
+  });
+
   describe("getTraineeDetail", () => {
     it("returns trainee with recent bookings + remainingEdits (now Infinity post-edit-limit-removal)", async () => {
       await bookings.book("t1", "slot-a", { bypass: true });
@@ -99,6 +178,17 @@ describe("CoachReadModel", () => {
     it("returns null for unknown trainee", async () => {
       const detail = await coachRead.getTraineeDetail("ghost");
       expect(detail).toBeNull();
+    });
+
+    it("carries progress aggregates on the trainee summary", async () => {
+      await progress.createMeasurement("t1", {
+        weightKg: 69,
+        loggedAt: new Date(Date.now() - 86_400_000),
+      });
+
+      const detail = await coachRead.getTraineeDetail("t1");
+      expect(detail!.trainee.lastWeightKg).toBe(69);
+      expect(detail!.trainee.lastMeasurementAt).not.toBeNull();
     });
   });
 

--- a/src/lib/coach/mock-read-model.ts
+++ b/src/lib/coach/mock-read-model.ts
@@ -11,9 +11,50 @@ import {
 import { BookingStore } from "@/lib/services/booking-store";
 import { AuthService } from "@/lib/services/auth";
 import { Bookings } from "@/lib/services/bookings";
+import { ProgressStore } from "@/lib/services/progress-store";
 import { loadProfile } from "@/lib/auth/profile-repo";
-import { Profile } from "@/lib/types";
+import { MeasurementLog, Profile } from "@/lib/types";
 import { todayIL, weekStartForDate, israelSlotToUTC } from "@/lib/services/israel-time";
+
+const FOURTEEN_DAYS_MS = 14 * 86_400_000;
+const TREND_FLAT_THRESHOLD_KG = 0.5;
+
+/**
+ * Weight trend over the trailing 14d: compares the newest weight to the newest
+ * weight that is at least 14 days older. `null` if there are fewer than two
+ * weight points, or no point old enough to compare against.
+ * `measurements` is newest-first (as ProgressStore.listMeasurements returns).
+ */
+function computeWeightTrend14d(
+  measurements: MeasurementLog[]
+): "up" | "flat" | "down" | null {
+  const points = measurements.filter((m) => m.weightKg != null);
+  if (points.length < 2) return null;
+  const newest = points[0];
+  const cutoff = newest.loggedAt.getTime() - FOURTEEN_DAYS_MS;
+  const older = points.find((m) => m.loggedAt.getTime() <= cutoff);
+  if (!older) return null;
+  const delta = newest.weightKg! - older.weightKg!;
+  if (Math.abs(delta) < TREND_FLAT_THRESHOLD_KG) return "flat";
+  return delta > 0 ? "up" : "down";
+}
+
+/**
+ * Attendance over the given roster entries: past-confirmed / (past-confirmed +
+ * no_show). `null` when there are no past sessions yet (so callers can hide a
+ * "100%" badge that would otherwise mislead for never-attended trainees).
+ */
+function computeAttendanceRate(entries: RosterEntry[]): number | null {
+  const now = Date.now();
+  const pastConfirmed = entries.filter(
+    (e) =>
+      e.status === "confirmed" &&
+      israelSlotToUTC(e.slotDate, e.slotTime).getTime() < now
+  ).length;
+  const noShows = entries.filter((e) => e.status === "no_show").length;
+  const total = pastConfirmed + noShows;
+  return total > 0 ? pastConfirmed / total : null;
+}
 
 /**
  * Composes BookingStore + AuthService + Bookings into the read-model.
@@ -24,8 +65,54 @@ import { todayIL, weekStartForDate, israelSlotToUTC } from "@/lib/services/israe
 export function makeCoachReadModel(
   store: BookingStore,
   auth: AuthService,
-  bookings: Bookings
+  bookings: Bookings,
+  progress: ProgressStore
 ): CoachReadModel {
+  /**
+   * Per-trainee progress aggregates for list/detail views. One measurement
+   * query per trainee (30d window — enough span to find a >=14d-older point
+   * for the trend). N+1 across the roster; acceptable at single-coach scale.
+   * If the roster grows large, add a batch ProgressStore.listLastMeasurements.
+   */
+  async function progressAggregates(traineeId: string): Promise<{
+    lastWeightKg: number | null;
+    weightTrend14d: "up" | "flat" | "down" | null;
+    lastMeasurementAt: string | null;
+  }> {
+    const ms = await progress.listMeasurements(traineeId, { sinceDays: 30 });
+    const lastWeight = ms.find((m) => m.weightKg != null);
+    return {
+      lastWeightKg: lastWeight?.weightKg ?? null,
+      weightTrend14d: computeWeightTrend14d(ms),
+      lastMeasurementAt: ms[0]?.loggedAt.toISOString() ?? null,
+    };
+  }
+
+  /**
+   * Overall attendance for a trainee (not capped to recent-10 like the detail
+   * view): builds roster entries from all their bookings, then applies the
+   * shared formula.
+   */
+  async function attendanceForTrainee(
+    traineeId: string,
+    byId: Map<string, Profile>
+  ): Promise<number | null> {
+    const all = await store.getTraineeBookings(traineeId);
+    const entries: RosterEntry[] = [];
+    for (const b of all) {
+      const entry = await buildRosterEntry(
+        b.id,
+        b.slotId,
+        b.traineeId,
+        b.isAutoBooked,
+        b.status,
+        byId
+      );
+      if (entry) entries.push(entry);
+    }
+    return computeAttendanceRate(entries);
+  }
+
   async function traineesByStatus(): Promise<{
     trainees: Profile[];
     byId: Map<string, Profile>;
@@ -120,7 +207,7 @@ export function makeCoachReadModel(
     },
 
     async getTraineesList(filter: TraineesFilter = "all"): Promise<TraineeSummary[]> {
-      const { trainees } = await traineesByStatus();
+      const { trainees, byId } = await traineesByStatus();
       const today = todayIL();
       const weekStart = weekStartForDate(today);
 
@@ -138,6 +225,7 @@ export function makeCoachReadModel(
 
         if (filter === "unbooked-this-week" && (bookedThisWeek || !t.isActive)) continue;
 
+        const agg = await progressAggregates(t.id);
         summaries.push({
           id: t.id,
           name: t.name,
@@ -148,6 +236,10 @@ export function makeCoachReadModel(
           preferredTime: t.preferredTime,
           bookedThisWeek,
           lastSessionAt: await lastSessionAt(t.id),
+          lastWeightKg: agg.lastWeightKg,
+          weightTrend14d: agg.weightTrend14d,
+          lastMeasurementAt: agg.lastMeasurementAt,
+          attendanceRate: await attendanceForTrainee(t.id, byId),
         });
       }
 
@@ -186,16 +278,12 @@ export function makeCoachReadModel(
 
       // Attendance rate: confirmed-past / (confirmed-past + no_show). Today the
       // only past terminal state is `confirmed` (auto-attended). Until Phase 16
-      // wires `no_show`, attendanceRate is always 1.0 for trainees with past bookings.
-      const now = Date.now();
-      const pastConfirmed = recentBookings.filter(
-        (e) =>
-          e.status === "confirmed" &&
-          israelSlotToUTC(e.slotDate, e.slotTime).getTime() < now
-      ).length;
-      const noShows = recentBookings.filter((e) => e.status === "no_show").length;
-      const attendanceRate =
-        pastConfirmed + noShows > 0 ? pastConfirmed / (pastConfirmed + noShows) : 1;
+      // wires `no_show`, attendanceRate is always 1.0 for trainees with past
+      // bookings. The detail view defaults a no-session trainee to 1.0 (legacy
+      // behavior); the list summary keeps it null so the chip can hide.
+      const rate = computeAttendanceRate(recentBookings);
+      const attendanceRate = rate ?? 1;
+      const agg = await progressAggregates(traineeId);
 
       return {
         trainee: {
@@ -210,6 +298,10 @@ export function makeCoachReadModel(
           preferredTime: t.preferredTime,
           bookedThisWeek: weekBookings.length > 0,
           lastSessionAt: await lastSessionAt(traineeId),
+          lastWeightKg: agg.lastWeightKg,
+          weightTrend14d: agg.weightTrend14d,
+          lastMeasurementAt: agg.lastMeasurementAt,
+          attendanceRate: rate,
         },
         recentBookings,
         attendanceRate,

--- a/src/lib/coach/read-model.ts
+++ b/src/lib/coach/read-model.ts
@@ -34,6 +34,10 @@ export type TraineeSummary = {
   preferredTime: string | null;
   bookedThisWeek: boolean;
   lastSessionAt: string | null; // ISO of most-recent confirmed past slot
+  lastWeightKg: number | null; // most-recent logged weight, null if never logged
+  weightTrend14d: "up" | "flat" | "down" | null; // vs a >=14d-older point; null if insufficient data
+  lastMeasurementAt: string | null; // ISO of most-recent measurement (any kind)
+  attendanceRate: number | null; // 0..1 over past bookings; null if no past sessions yet
 };
 
 export type TraineeDetailView = {

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -125,7 +125,7 @@ function buildContainer(): Container {
   const notifier = getNotificationService();
   const bookings = makeBookings(store, calendar, notifier);
   const auth = getAuthService();
-  const coachRead = makeCoachReadModel(store, auth, bookings);
   const progress = getProgressStore();
+  const coachRead = makeCoachReadModel(store, auth, bookings, progress);
   return { store, bookings, auth, coachRead, progress };
 }


### PR DESCRIPTION
Closes #62 (epic #52 follow-up).

## What
Coach-side progress visibility — the "professional coaching UX" pattern (TrueCoach/Trainerize), validated by the fitness best-practices doc as social accountability without shaming.

### Backend — `CoachReadModel.TraineeSummary` aggregates
- `lastWeightKg`, `weightTrend14d` (`up`/`flat`/`down`/null), `lastMeasurementAt`, `attendanceRate`.
- Trend = newest weight vs newest weight ≥14d older; `|Δ|<0.5kg` → flat; null if <2 points or none old enough.
- `attendanceRate` **nullable** on the summary (null = no past sessions) so the chip hides instead of showing a misleading "100%". Detail view keeps its 1.0 default.
- Threaded `progress: ProgressStore` into the single composed `makeCoachReadModel` (works mock + prod). New fields surfaced in `/api/admin/trainees`.

### Mobile
- **Detail card**: `_ProgressCard` on the coach trainee-detail screen reuses `WeightChart` + a measurement-log list, fed by `coachProgressProvider.family` hitting the existing `GET /api/admin/trainees/:id/progress` (no backend change).
- **List chips**: teal weight+trend-arrow chip + muted attendance-% chip on each trainees-list row; both hide when their datum is absent.

## Constraints honored
- No new chart dependency — custom-painter `WeightChart` reused (no fl_chart).
- N+1 progress/attendance per trainee accepted at single-coach scale (commented; batch method noted for future).

## Tests
- Backend: 318 vitest (+10), `tsc --noEmit` clean, eslint clean.
- Mobile: 124 flutter_test (+7), `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
