### PR TITLE
feat: searchable + sortable coach trainee list (#66)

### DIFF
--- a/mobile/lib/features/coach/coach_trainees_screen.dart
+++ b/mobile/lib/features/coach/coach_trainees_screen.dart
@@ -33,16 +33,88 @@ Color statusColor(BuildContext c, String status) {
   }
 }
 
-class CoachTraineesScreen extends ConsumerWidget {
+/// Sort modes for the coach trainees list (#66). `byName` keeps the
+/// as-fetched order (default); the others reuse the #62 progress aggregates.
+enum TraineeSort { byName, byAttendance, byActivity }
+
+/// Nulls always sort last regardless of direction.
+int _cmpNullableDesc<T extends Comparable<T>>(T? a, T? b) {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+  return b.compareTo(a);
+}
+
+class CoachTraineesScreen extends ConsumerStatefulWidget {
   const CoachTraineesScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<CoachTraineesScreen> createState() =>
+      _CoachTraineesScreenState();
+}
+
+class _CoachTraineesScreenState extends ConsumerState<CoachTraineesScreen> {
+  final _search = TextEditingController();
+  TraineeSort _sort = TraineeSort.byName;
+
+  @override
+  void dispose() {
+    _search.dispose();
+    super.dispose();
+  }
+
+  List<TraineeRecord> _filterAndSort(List<TraineeRecord> list) {
+    final q = _search.text.trim().toLowerCase();
+    var out = q.isEmpty
+        ? List<TraineeRecord>.from(list)
+        : list
+            .where((t) =>
+                t.name.toLowerCase().contains(q) ||
+                (t.email?.toLowerCase().contains(q) ?? false))
+            .toList();
+    switch (_sort) {
+      case TraineeSort.byName:
+        break; // preserve as-fetched order
+      case TraineeSort.byAttendance:
+        out.sort((a, b) => _cmpNullableDesc(a.attendanceRate, b.attendanceRate));
+      case TraineeSort.byActivity:
+        out.sort(
+            (a, b) => _cmpNullableDesc(a.lastMeasurementAt, b.lastMeasurementAt));
+    }
+    return out;
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final async = ref.watch(traineeRecordsProvider);
     return Scaffold(
       appBar: AppBar(
         title: const Text('מתאמנים'),
         actions: [
+          PopupMenuButton<TraineeSort>(
+            key: const Key('sort-button'),
+            tooltip: 'מיון',
+            icon: const Icon(Icons.sort),
+            initialValue: _sort,
+            onSelected: (v) => setState(() => _sort = v),
+            itemBuilder: (_) => const [
+              PopupMenuItem(
+                key: Key('sort-name'),
+                value: TraineeSort.byName,
+                child: Text('ברירת מחדל'),
+              ),
+              PopupMenuItem(
+                key: Key('sort-attendance'),
+                value: TraineeSort.byAttendance,
+                child: Text('נוכחות'),
+              ),
+              PopupMenuItem(
+                key: Key('sort-activity'),
+                value: TraineeSort.byActivity,
+                child: Text('פעילות אחרונה'),
+              ),
+            ],
+          ),
           IconButton(
             key: const Key('invite-trainee-button'),
             tooltip: 'הזמן מתאמן',
@@ -78,10 +150,38 @@ class CoachTraineesScreen extends ConsumerWidget {
               ),
             );
           }
-          return ListView.separated(
-            itemCount: trainees.length,
-            separatorBuilder: (_, _) => const Divider(height: 1),
-            itemBuilder: (_, i) => _TraineeRow(trainee: trainees[i]),
+          final filtered = _filterAndSort(trainees);
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.md, AppSpacing.sm, AppSpacing.md, AppSpacing.xs),
+                child: TextField(
+                  key: const Key('trainee-search'),
+                  controller: _search,
+                  onChanged: (_) => setState(() {}),
+                  decoration: const InputDecoration(
+                    prefixIcon: Icon(Icons.search),
+                    hintText: 'חיפוש לפי שם או אימייל',
+                    isDense: true,
+                  ),
+                ),
+              ),
+              Expanded(
+                child: filtered.isEmpty
+                    ? const EmptyState(
+                        key: Key('trainees-no-match'),
+                        icon: Icons.search_off,
+                        headline: 'לא נמצאו מתאמנים',
+                        helper: 'נסה חיפוש אחר',
+                      )
+                    : ListView.separated(
+                        itemCount: filtered.length,
+                        separatorBuilder: (_, _) => const Divider(height: 1),
+                        itemBuilder: (_, i) => _TraineeRow(trainee: filtered[i]),
+                      ),
+              ),
+            ],
           );
         },
       ),

--- a/mobile/test/features/coach/coach_trainees_screen_test.dart
+++ b/mobile/test/features/coach/coach_trainees_screen_test.dart
@@ -135,6 +135,112 @@ void main() {
       expect(find.byKey(const Key('attendance-chip-t1')), findsNothing);
     });
 
+    TraineeRecord recOf(String id, String name,
+            {String? email, double? attendance, DateTime? lastMeasurement}) =>
+        TraineeRecord(
+          id: id,
+          name: name,
+          email: email,
+          status: 'active',
+          isRecurring: false,
+          attendanceRate: attendance,
+          lastMeasurementAt: lastMeasurement,
+        );
+
+    double rowDy(WidgetTester tester, String id) =>
+        tester.getCenter(find.byKey(Key('trainee-row-$id'))).dy;
+
+    testWidgets('search filters by name', (tester) async {
+      final admin = _FakeAdminRepo();
+      when(() => admin.listTrainees()).thenAnswer((_) async => [
+            recOf('t1', 'יעל כהן'),
+            recOf('t2', 'איתי לוי'),
+          ]);
+
+      await tester.pumpWidget(_harness(admin: admin));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byKey(const Key('trainee-search')), 'איתי');
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('trainee-row-t2')), findsOneWidget);
+      expect(find.byKey(const Key('trainee-row-t1')), findsNothing);
+    });
+
+    testWidgets('search filters by email', (tester) async {
+      final admin = _FakeAdminRepo();
+      when(() => admin.listTrainees()).thenAnswer((_) async => [
+            recOf('t1', 'יעל', email: 'yael@example.com'),
+            recOf('t2', 'איתי', email: 'itai@example.com'),
+          ]);
+
+      await tester.pumpWidget(_harness(admin: admin));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byKey(const Key('trainee-search')), 'yael@');
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('trainee-row-t1')), findsOneWidget);
+      expect(find.byKey(const Key('trainee-row-t2')), findsNothing);
+    });
+
+    testWidgets('no match shows empty state', (tester) async {
+      final admin = _FakeAdminRepo();
+      when(() => admin.listTrainees())
+          .thenAnswer((_) async => [recOf('t1', 'יעל')]);
+
+      await tester.pumpWidget(_harness(admin: admin));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byKey(const Key('trainee-search')), 'zzzzz');
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('trainees-no-match')), findsOneWidget);
+      expect(find.byKey(const Key('trainee-row-t1')), findsNothing);
+    });
+
+    testWidgets('sort by attendance orders highest first, null last',
+        (tester) async {
+      final admin = _FakeAdminRepo();
+      when(() => admin.listTrainees()).thenAnswer((_) async => [
+            recOf('t1', 'A', attendance: 0.5),
+            recOf('t2', 'B', attendance: 0.9),
+            recOf('t3', 'C'), // null attendance
+          ]);
+
+      await tester.pumpWidget(_harness(admin: admin));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('sort-button')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('sort-attendance')));
+      await tester.pumpAndSettle();
+
+      expect(rowDy(tester, 't2'), lessThan(rowDy(tester, 't1')));
+      expect(rowDy(tester, 't1'), lessThan(rowDy(tester, 't3')));
+    });
+
+    testWidgets('sort by activity orders most-recent first, null last',
+        (tester) async {
+      final admin = _FakeAdminRepo();
+      when(() => admin.listTrainees()).thenAnswer((_) async => [
+            recOf('t1', 'A'), // null activity
+            recOf('t2', 'B', lastMeasurement: DateTime(2026, 5, 1)),
+            recOf('t3', 'C', lastMeasurement: DateTime(2026, 5, 20)),
+          ]);
+
+      await tester.pumpWidget(_harness(admin: admin));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('sort-button')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const Key('sort-activity')));
+      await tester.pumpAndSettle();
+
+      expect(rowDy(tester, 't3'), lessThan(rowDy(tester, 't2')));
+      expect(rowDy(tester, 't2'), lessThan(rowDy(tester, 't1')));
+    });
+
     testWidgets('invite form submits email + name', (tester) async {
       final admin = _FakeAdminRepo();
       when(() => admin.listTrainees()).thenAnswer((_) async => []);


### PR DESCRIPTION
Closes #66 (epic #52 · best-practices follow-up).

## What
Coach trainees list becomes searchable + sortable — surfacing who's slipping vs thriving at a glance.

- **Search**: name/email, case-insensitive, contains-match (RTL input). No-match → friendly empty state.
- **Sort** (popup menu): default (as-fetched) · by attendance (desc) · by last activity (recent first). Nulls always sort last.

Pure client-side over the existing `traineeRecordsProvider`, reusing the `attendanceRate` + `lastMeasurementAt` aggregates shipped in #62 — no new endpoint.

## Tests
- 129 flutter_test (+5: name filter, email filter, no-match, attendance sort, activity sort).
- `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
