### PR TITLE
feat: coach inbox as glanceable dashboard hero (#67)

### DIFF
--- a/mobile/lib/features/coach/coach_week_screen.dart
+++ b/mobile/lib/features/coach/coach_week_screen.dart
@@ -85,6 +85,7 @@ class _CoachWeekScreenState extends ConsumerState<CoachWeekScreen> {
       body: Column(
         children: [
           _CoachDashboard(now: widget.now, selectedDate: _selectedDate),
+          const _InboxHero(),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
             child: Row(
@@ -289,6 +290,139 @@ class _DashSpacer extends StatelessWidget {
   const _DashSpacer();
   @override
   Widget build(BuildContext context) => const Expanded(child: SizedBox.shrink());
+}
+
+/// Glanceable inbox (#67): pending approvals + inside-24h change requests
+/// surfaced at the top with one-tap entry. When both are zero it shows a calm
+/// "all clear" — no fake urgency, just peace of mind (behavioral rule 1).
+class _InboxHero extends ConsumerWidget {
+  const _InboxHero();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final dashboard = ref.watch(coachDashboardProvider).valueOrNull;
+    if (dashboard == null) return const SizedBox.shrink(); // dashboard hero covers loading
+    final approvals = dashboard.pendingApprovals;
+    final requests = dashboard.pendingChangeRequests;
+
+    if (approvals + requests == 0) {
+      return Padding(
+        padding: const EdgeInsets.fromLTRB(
+            AppSpacing.md, AppSpacing.sm, AppSpacing.md, 0),
+        child: Row(
+          key: const Key('inbox-all-clear'),
+          children: [
+            const Icon(Icons.check_circle_outline,
+                size: 18, color: BrandColors.success),
+            const SizedBox(width: AppSpacing.xs),
+            Text(
+              'אין משימות ממתינות',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: BrandColors.inkMuted,
+                  ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Padding(
+      padding:
+          const EdgeInsets.fromLTRB(AppSpacing.md, AppSpacing.sm, AppSpacing.md, 0),
+      child: Container(
+        key: const Key('inbox-hero'),
+        decoration: BoxDecoration(
+          color: BrandColors.orange.withValues(alpha: 0.06),
+          borderRadius: BorderRadius.circular(AppSpacing.radiusLg),
+          border: const Border(
+            right: BorderSide(color: BrandColors.orange, width: 3),
+          ),
+        ),
+        padding: const EdgeInsets.all(AppSpacing.sm),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SectionHeader('תיבת נכנסים'),
+            if (approvals > 0)
+              _InboxRow(
+                rowKey: const Key('inbox-approvals'),
+                icon: Icons.how_to_reg_outlined,
+                label: 'אישורי מתאמנים ממתינים',
+                count: approvals,
+                onTap: () => Navigator.of(context).push(
+                  MaterialPageRoute(
+                      builder: (_) => const PendingApprovalsScreen()),
+                ),
+              ),
+            if (requests > 0)
+              _InboxRow(
+                rowKey: const Key('inbox-requests'),
+                icon: Icons.swap_horiz,
+                label: 'בקשות שינוי',
+                count: requests,
+                onTap: () => Navigator.of(context).push(
+                  MaterialPageRoute(builder: (_) => const ChangeRequestsScreen()),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InboxRow extends StatelessWidget {
+  final Key rowKey;
+  final IconData icon;
+  final String label;
+  final int count;
+  final VoidCallback onTap;
+  const _InboxRow({
+    required this.rowKey,
+    required this.icon,
+    required this.label,
+    required this.count,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      key: rowKey,
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(AppSpacing.radiusSm),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+        child: Row(
+          children: [
+            Icon(icon, size: 20, color: BrandColors.orange),
+            const SizedBox(width: AppSpacing.sm),
+            Expanded(
+              child: Text(label, style: theme.textTheme.bodyMedium),
+            ),
+            Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 8, vertical: 1),
+              decoration: BoxDecoration(
+                color: BrandColors.orange,
+                borderRadius: BorderRadius.circular(AppSpacing.radiusPill),
+              ),
+              child: Text(
+                '$count',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ),
+            const SizedBox(width: AppSpacing.xs),
+            const Icon(Icons.chevron_left, size: 18, color: BrandColors.inkMuted),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 class _DashStat extends StatelessWidget {

--- a/mobile/test/features/coach/coach_inbox_hero_test.dart
+++ b/mobile/test/features/coach/coach_inbox_hero_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:velofit/features/coach/admin_repository.dart';
+import 'package:velofit/features/coach/coach_dashboard_repository.dart';
+import 'package:velofit/features/coach/coach_week_screen.dart';
+import 'package:velofit/features/coach/pending_approvals_screen.dart';
+import 'package:velofit/features/slots/slot_repository.dart';
+
+class _FakeSlotRepo extends Mock implements SlotRepository {}
+
+class _FakeAdminRepo extends Mock implements AdminRepository {}
+
+class _FakeDashboardRepo extends Mock implements CoachDashboardRepository {}
+
+Widget _harness({required int approvals, required int requests}) {
+  final slots = _FakeSlotRepo();
+  final admin = _FakeAdminRepo();
+  final dash = _FakeDashboardRepo();
+  when(() => slots.fetchSlots(any())).thenAnswer((_) async => []);
+  when(() => admin.fetchBookings(date: any(named: 'date')))
+      .thenAnswer((_) async => []);
+  when(() => admin.listTrainees()).thenAnswer((_) async => []);
+  when(() => dash.fetch()).thenAnswer((_) async => CoachDashboardView(
+        pendingApprovals: approvals,
+        pendingChangeRequests: requests,
+        noShowsThisWeek: 0,
+        todayRosterCount: 0,
+      ));
+  return ProviderScope(
+    overrides: [
+      slotRepositoryProvider.overrideWithValue(slots),
+      adminRepositoryProvider.overrideWithValue(admin),
+      coachDashboardRepositoryProvider.overrideWithValue(dash),
+    ],
+    child: MaterialApp(
+      builder: (context, child) => Directionality(
+        textDirection: TextDirection.rtl,
+        child: child ?? const SizedBox.shrink(),
+      ),
+      home: CoachWeekScreen(now: DateTime(2026, 5, 20)),
+    ),
+  );
+}
+
+/// Tall viewport so the empty-week EmptyState below the hero isn't squeezed
+/// into an overflow in the default 600px test window (real devices have room).
+Future<void> _pump(WidgetTester tester, Widget w) async {
+  tester.view.physicalSize = const Size(1100, 2200);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  await tester.pumpWidget(w);
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  setUpAll(() => registerFallbackValue(''));
+
+  group('CoachWeekScreen inbox hero', () {
+    testWidgets('shows hero with both rows + counts when work pending',
+        (tester) async {
+      await _pump(tester, _harness(approvals: 2, requests: 1));
+
+      expect(find.byKey(const Key('inbox-hero')), findsOneWidget);
+      expect(find.byKey(const Key('inbox-approvals')), findsOneWidget);
+      expect(find.byKey(const Key('inbox-requests')), findsOneWidget);
+      expect(find.text('תיבת נכנסים'), findsOneWidget);
+      expect(find.text('2'), findsWidgets); // approvals badge
+    });
+
+    testWidgets('shows only approvals row when no change requests',
+        (tester) async {
+      await _pump(tester, _harness(approvals: 3, requests: 0));
+
+      expect(find.byKey(const Key('inbox-approvals')), findsOneWidget);
+      expect(find.byKey(const Key('inbox-requests')), findsNothing);
+    });
+
+    testWidgets('shows calm all-clear when nothing pending', (tester) async {
+      await _pump(tester, _harness(approvals: 0, requests: 0));
+
+      expect(find.byKey(const Key('inbox-all-clear')), findsOneWidget);
+      expect(find.byKey(const Key('inbox-hero')), findsNothing);
+      expect(find.text('אין משימות ממתינות'), findsOneWidget);
+    });
+
+    testWidgets('tapping approvals row routes to PendingApprovalsScreen',
+        (tester) async {
+      await _pump(tester, _harness(approvals: 1, requests: 0));
+
+      await tester.tap(find.byKey(const Key('inbox-approvals')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PendingApprovalsScreen), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #67 (epic #52 · best-practices follow-up).

## What
Elevates the coach inbox to a glanceable hero at the top of the coach week screen — so pending work is the first thing seen and nothing waits unnoticed.

- Orange-accented **inbox card** with one-tap rows: pending approvals → `PendingApprovalsScreen`, inside-24h change-requests → `ChangeRequestsScreen`. (Approvals previously had no entry point from the dashboard.)
- Each row renders only when its count > 0.
- When both are zero → a calm **"אין משימות ממתינות"** all-clear, not an empty card. No fake urgency (behavioral rule 1).
- Counts come from the existing `coachDashboardProvider`; while loading (null) the hero adds nothing (the dashboard hero already covers that state).

## Tests
- 133 flutter_test (+4: both rows, approvals-only, all-clear, tap-routes-to-approvals).
- `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
