### PR TITLE
feat: haptics vocabulary — light on book/log, heavy on no-show (#69)

### DIFF
--- a/mobile/lib/features/coach/coach_week_screen.dart
+++ b/mobile/lib/features/coach/coach_week_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../design/spacing.dart';
 import '../../design/widgets.dart';
 import '../../theme.dart';
+import '../../utils/haptics.dart';
 import '../../utils/week_dates.dart';
 import '../profile/profile_screen.dart';
 import '../slots/slot.dart';
@@ -551,6 +552,7 @@ class _CoachSlotTile extends ConsumerWidget {
     try {
       await ref.read(adminRepositoryProvider).markNoShow(booking.id);
       if (!context.mounted) return;
+      Haptics.noShowMark();
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('סומן כלא הופיע')),
       );

--- a/mobile/lib/features/progress/measurement_logger_sheet.dart
+++ b/mobile/lib/features/progress/measurement_logger_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../design/spacing.dart';
+import '../../utils/haptics.dart';
 import 'progress.dart';
 import 'progress_repository.dart';
 
@@ -57,6 +58,7 @@ class _MeasurementLoggerSheetState
     try {
       await ref.read(progressRepositoryProvider).logMeasurement(input);
       if (!mounted) return;
+      Haptics.logSaved();
       ref.invalidate(progressProvider);
       Navigator.of(context).pop();
       ScaffoldMessenger.of(context).showSnackBar(

--- a/mobile/lib/features/slots/home_screen.dart
+++ b/mobile/lib/features/slots/home_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../design/spacing.dart';
 import '../../design/widgets.dart';
 import '../../theme.dart';
+import '../../utils/haptics.dart';
 import '../../utils/week_dates.dart';
 import '../bookings/booking.dart';
 import '../bookings/booking_repository.dart';
@@ -64,6 +65,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     try {
       await ref.read(bookingRepositoryProvider).book(slot.id);
       if (!mounted) return;
+      Haptics.bookingSuccess();
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('האימון נקבע')),
       );

--- a/mobile/lib/utils/haptics.dart
+++ b/mobile/lib/utils/haptics.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/services.dart';
+
+/// Centralized haptic vocabulary (#69).
+///
+/// Haptic + checkmark + instant UI update IS the reward — explicitly NOT
+/// confetti (product-vision behavioral rule 3). Named intents keep usage
+/// consistent across flows and make the mapping testable in one place.
+class Haptics {
+  const Haptics._();
+
+  /// Positive trainee action — a booking confirmed.
+  static Future<void> bookingSuccess() => HapticFeedback.lightImpact();
+
+  /// Positive trainee action — a measurement / session log saved.
+  static Future<void> logSaved() => HapticFeedback.lightImpact();
+
+  /// Coach marks a no-show — a heavier, distinct signal for a weightier action.
+  static Future<void> noShowMark() => HapticFeedback.heavyImpact();
+
+  /// Selecting a slot / day.
+  static Future<void> select() => HapticFeedback.mediumImpact();
+}

--- a/mobile/test/utils/haptics_test.dart
+++ b/mobile/test/utils/haptics_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:velofit/utils/haptics.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final calls = <MethodCall>[];
+  setUp(() {
+    calls.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      calls.add(call);
+      return null;
+    });
+  });
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  Future<void> expectFeedback(
+      Future<void> Function() intent, String type) async {
+    await intent();
+    final haptic = calls.where((c) => c.method == 'HapticFeedback.vibrate');
+    expect(haptic, hasLength(1));
+    expect(haptic.single.arguments, type);
+  }
+
+  test('bookingSuccess → lightImpact', () async {
+    await expectFeedback(Haptics.bookingSuccess, 'HapticFeedbackType.lightImpact');
+  });
+
+  test('logSaved → lightImpact', () async {
+    await expectFeedback(Haptics.logSaved, 'HapticFeedbackType.lightImpact');
+  });
+
+  test('noShowMark → heavyImpact', () async {
+    await expectFeedback(Haptics.noShowMark, 'HapticFeedbackType.heavyImpact');
+  });
+
+  test('select → mediumImpact', () async {
+    await expectFeedback(Haptics.select, 'HapticFeedbackType.mediumImpact');
+  });
+}


### PR DESCRIPTION
Closes #69 (epic #52 · best-practices follow-up).

## What
A consistent haptic vocabulary as the reward signal — explicitly **not** confetti (behavioral rule 3).

Centralized `Haptics` helper wrapping `HapticFeedback` with named intents:
- `bookingSuccess()` → light impact
- `logSaved()` → light impact
- `noShowMark()` → **heavy** impact (weightier coach action)
- `select()` → medium impact

Wired into the existing **book**, **measurement-log**, and coach **no-show** flows.

## Tests
- 137 flutter_test (+4: each intent asserts the exact `HapticFeedback.vibrate` platform-channel argument).
- `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
