### PR TITLE
feat: first-session CTA on trainee landing (#68)

### DIFF
--- a/mobile/lib/features/slots/home_screen.dart
+++ b/mobile/lib/features/slots/home_screen.dart
@@ -30,6 +30,21 @@ class HomeScreen extends ConsumerStatefulWidget {
 class _HomeScreenState extends ConsumerState<HomeScreen> {
   late int _selectedIndex;
   late List<DateTime> _weekDates;
+  final _slotsSectionKey = GlobalKey();
+
+  /// Bring the "available slots" section into view — the action behind the
+  /// first-session CTA (#68), so a newly-approved trainee gets to booking in
+  /// one tap instead of scrolling past the welcome cards.
+  void _scrollToSlots() {
+    final ctx = _slotsSectionKey.currentContext;
+    if (ctx == null) return;
+    Scrollable.ensureVisible(
+      ctx,
+      duration: const Duration(milliseconds: 400),
+      curve: Curves.easeOut,
+      alignment: 0.05,
+    );
+  }
 
   @override
   void initState() {
@@ -116,7 +131,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 const _CoachNoteCard(),
                 const _UpcomingSessionsCard(),
                 const _MyBookingsSection(),
+                if (myBookingsView != null && bookedSlotIds.isEmpty)
+                  _FirstSessionCta(onFindSlot: _scrollToSlots),
                 Padding(
+                  key: _slotsSectionKey,
                   padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
                   child: Text('מועדים פנויים',
                       style: Theme.of(context).textTheme.titleMedium),
@@ -508,6 +526,60 @@ class _UpcomingSessionsCard extends ConsumerWidget {
           ),
         );
       },
+    );
+  }
+}
+
+/// First-session nudge (#68): shown on the active-trainee landing when there
+/// are no confirmed bookings yet — turns "you're approved" into immediate value
+/// with a one-tap jump to bookable slots. Positive framing, no fake urgency.
+class _FirstSessionCta extends StatelessWidget {
+  final VoidCallback onFindSlot;
+  const _FirstSessionCta({required this.onFindSlot});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+      child: Card(
+        key: const Key('first-session-cta'),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Icon(Icons.fitness_center,
+                      size: 20, color: theme.colorScheme.primary),
+                  const SizedBox(width: AppSpacing.sm),
+                  Expanded(
+                    child: Text('זמן לאימון הראשון',
+                        style: theme.textTheme.titleSmall),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.xs),
+              Text(
+                'בחר מועד שנוח לך וקבע את האימון הראשון — מכאן הכול מתחיל.',
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: BrandColors.inkSoft),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Align(
+                alignment: AlignmentDirectional.centerStart,
+                child: FilledButton.tonalIcon(
+                  key: const Key('find-slot-cta'),
+                  onPressed: onFindSlot,
+                  icon: const Icon(Icons.event_available, size: 18),
+                  label: const Text('מצא מועד פנוי'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/test/features/slots/home_screen_test.dart
+++ b/mobile/test/features/slots/home_screen_test.dart
@@ -626,6 +626,7 @@ void main() {
       await tester.pumpWidget(_harness(repo: repo, bookings: bookings));
       await tester.pumpAndSettle();
 
+      await tester.ensureVisible(find.byKey(const Key('slot-10:00')));
       await tester.tap(find.byKey(const Key('slot-10:00')));
       await tester.pumpAndSettle();
       await tester.tap(find.text('אישור'));
@@ -649,6 +650,7 @@ void main() {
       // initial fetch
       verify(() => repo.fetchSlots(any())).called(1);
 
+      await tester.ensureVisible(find.byKey(const Key('slot-10:00')));
       await tester.tap(find.byKey(const Key('slot-10:00')));
       await tester.pumpAndSettle();
       await tester.tap(find.text('אישור'));
@@ -684,6 +686,7 @@ void main() {
       ), findsOneWidget);
 
       // Tapping the booked slot should NOT open the dialog.
+      await tester.ensureVisible(find.byKey(const Key('slot-10:00')));
       await tester.tap(find.byKey(const Key('slot-10:00')));
       await tester.pumpAndSettle();
       expect(find.byKey(const Key('booking-confirm-dialog')), findsNothing);
@@ -741,6 +744,7 @@ void main() {
       await tester.pumpWidget(_harness(repo: repo, bookings: bookings));
       await tester.pumpAndSettle();
 
+      await tester.ensureVisible(find.byKey(const Key('slot-10:00')));
       await tester.tap(find.byKey(const Key('slot-10:00')));
       await tester.pumpAndSettle();
       await tester.tap(find.text('אישור'));
@@ -759,6 +763,7 @@ void main() {
       await tester.pumpWidget(_harness(repo: repo, bookings: bookings));
       await tester.pumpAndSettle();
 
+      await tester.ensureVisible(find.byKey(const Key('slot-10:00')));
       await tester.tap(find.byKey(const Key('slot-10:00')));
       await tester.pumpAndSettle();
 
@@ -766,6 +771,60 @@ void main() {
       expect(find.text('לקבוע אימון לשעה 10:00?'), findsOneWidget);
       expect(find.text('אישור'), findsOneWidget);
       expect(find.text('ביטול'), findsOneWidget);
+    });
+
+    testWidgets('first-session CTA shows when trainee has no confirmed bookings (#68)',
+        (tester) async {
+      final repo = _FakeSlotRepo();
+      final bookings = _FakeBookingRepo();
+      when(() => repo.fetchSlots(any())).thenAnswer((_) async => [_aSlot]);
+      when(() => bookings.fetchMyBookings()).thenAnswer((_) async =>
+          const MyBookingsView(remainingEdits: 3, bookings: []));
+
+      await tester.pumpWidget(_harness(repo: repo, bookings: bookings));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('first-session-cta')), findsOneWidget);
+      expect(find.byKey(const Key('find-slot-cta')), findsOneWidget);
+    });
+
+    testWidgets('first-session CTA hidden when a confirmed booking exists (#68)',
+        (tester) async {
+      final repo = _FakeSlotRepo();
+      final bookings = _FakeBookingRepo();
+      when(() => repo.fetchSlots(any())).thenAnswer((_) async => [_aSlot]);
+      when(() => bookings.fetchMyBookings()).thenAnswer((_) async =>
+          const MyBookingsView(remainingEdits: 3, bookings: [
+            Booking(
+              id: 'b1',
+              slotId: 's1',
+              traineeId: 't1',
+              status: 'confirmed',
+              slotDate: '2026-05-20',
+              slotStartTime: '10:00',
+            ),
+          ]));
+
+      await tester.pumpWidget(_harness(repo: repo, bookings: bookings));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key('first-session-cta')), findsNothing);
+    });
+
+    testWidgets('tapping find-slot CTA does not throw (#68)', (tester) async {
+      final repo = _FakeSlotRepo();
+      final bookings = _FakeBookingRepo();
+      when(() => repo.fetchSlots(any())).thenAnswer((_) async => [_aSlot]);
+      when(() => bookings.fetchMyBookings()).thenAnswer((_) async =>
+          const MyBookingsView(remainingEdits: 3, bookings: []));
+
+      await tester.pumpWidget(_harness(repo: repo, bookings: bookings));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('find-slot-cta')));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
     });
   });
 }


### PR DESCRIPTION
Closes #68 (epic #52 · best-practices follow-up).

## Finding
The active-trainee `HomeScreen` **already** surfaces available slots ("מועדים פנויים" + day picker + slot list) on the same landing screen — `role_router` routes pending→active straight to it, so there's no "you're approved" dead-end. The only real gap was the absence of a first-session nudge for a brand-new trainee (both bookings cards collapse to nothing when empty).

## What
Adds a friendly **first-session CTA** card, shown only when the trainee has no confirmed bookings: "זמן לאימון הראשון" + a one-tap "מצא מועד פנוי" button that scrolls to the slots section. Positive framing, no fake urgency (behavioral rule 1). Disappears once any booking exists.

Broader new-user card reordering (e.g. floating slots above the coach cards) is left as a product decision — flagged for follow-up rather than guessed.

## Tests
- 140 flutter_test (+3: CTA shown when empty, hidden with a booking, tap doesn't throw). Adjusted 5 existing slot-tap tests to `ensureVisible` first (the CTA legitimately pushes slots down in the 600px test viewport).
- `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
