### PR TITLE
feat: motion foundation — flutter_animate + gated shimmer (ADR-0008)

### DIFF
--- a/docs/adr/0008-motion-layer-flutter-animate-with-global-gate.md
+++ b/docs/adr/0008-motion-layer-flutter-animate-with-global-gate.md
@@ -1,0 +1,18 @@
+# Motion layer: flutter_animate + a global infinite-motion gate
+
+Velofit adopts a deliberate motion layer to feel alive and premium (2026 fitness-app bar) without gamification overload. Everyday motion uses **`flutter_animate`** (declarative, RTL-safe, ~tiny) plus Flutter's built-in implicit `AnimatedX` widgets. Tokens live in `mobile/lib/design/motion.dart` (`AppMotion`): durations (micro 120ms → emphasized 400ms), curves (entry `easeOutCubic`, exit `easeInCubic`, `springy` `easeOutBack`), and a per-item `stagger`.
+
+**Infinite/repeating** animations (shimmer, pulse, wiggle) are gated behind `AppMotion.infiniteMotionEnabled(context)`, which is false when either (a) the OS "reduce motion" accessibility flag is set, or (b) `AppMotion.disableInfiniteForTests` is true. `test/flutter_test_config.dart` (auto-loaded by `flutter test` for the whole package) flips that bool, so loops collapse to a single static frame and never hang `pumpAndSettle`. Finite animations (entries, press, count-ups) need no gate — they settle.
+
+## Considered options
+
+- **`flutter_animate` for the everyday layer + implicits** — chosen. One small dependency covers staggered reveals, fades/slides, shimmer, and press effects declaratively; implicit `AnimatedX` covers state changes. Runs well on mid-range Android (common in IL). No asset pipeline.
+- **Zero new dependencies (implicits only)** — rejected. `AnimatedContainer`/`Opacity`/`Scale` + `TweenAnimationBuilder` can do most of it, but staggers and shimmer become hand-rolled `AnimationController` boilerplate in every screen. More code, more ticker-leak risk, no real upside.
+- **Lottie / Rive for set-pieces** — deferred (not rejected). Bespoke vector/state-machine animations (streak character, marquee success burst) need designer-made assets and add bundle weight. Revisit if a specific hero moment justifies it; the everyday layer does not.
+
+## Consequences
+
+- Every looping animation MUST go through `AppMotion.infiniteMotionEnabled` or it will hang the test suite and ignore the user's reduce-motion preference. Finite animations are free to use directly.
+- `SkeletonList` now shimmers (gated); its old "static so tests don't hang" constraint is replaced by the global gate.
+- **Locked product rules still hold:** no confetti on transactional actions (vision rule 3 — a checkmark-draw + haptic is the reward), and charts remain custom-painter (`WeightChart`), not `fl_chart`. The motion layer celebrates within those rules.
+- Reduce-motion is now a first-class accessibility path, not an afterthought.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -48,6 +48,26 @@ Heebo (Hebrew sans). Sizes through `Theme.of(context).textTheme.*` — never har
 | Body | `bodyMedium` (14) |
 | Meta / caption | `labelSmall` (12) |
 
+### Motion (`mobile/lib/design/motion.dart` → `AppMotion`, ADR-0008)
+
+`flutter_animate` for the declarative everyday layer; Flutter implicit `AnimatedX` for state. Tokens, never raw values.
+
+| Token | Value | Use |
+|---|---|---|
+| `micro` | 120ms | press / tap acknowledgement |
+| `fast` | 200ms | small state changes (chip, icon swap) |
+| `standard` | 250ms | entries, `AnimatedSwitcher` crossfades |
+| `emphasized` | 400ms | hero reveals, number count-ups |
+| `stagger` | 55ms | per-item delay in a list reveal |
+| `entry` / `exit` | `easeOutCubic` / `easeInCubic` | appearing / leaving |
+| `springy` | `easeOutBack` | press release, pops |
+
+**Rules:**
+- **Infinite/repeating** animations (shimmer, pulse, wiggle) MUST gate behind `AppMotion.infiniteMotionEnabled(context)` — honors OS reduce-motion and prevents `pumpAndSettle` hangs (tests set `disableInfiniteForTests`). Finite animations need no gate.
+- Press feedback on primary affordances via `PressableScale` (scale 0.97, `springy`).
+- Reward stays rule-3 compliant: checkmark-draw + haptic on success. **No confetti.** Charts stay custom-painter — **no `fl_chart`.**
+- Durations short (≤400ms); curves simple; test on mid-range Android.
+
 ## 2. Pattern library (shipped, in `mobile/lib/design/widgets.dart`)
 
 | Widget | Use | Notes |

--- a/mobile/lib/design/motion.dart
+++ b/mobile/lib/design/motion.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+
+/// Velofit motion tokens + gate.
+///
+/// One source of truth for durations and curves so every animated widget
+/// shares the same rhythm. Built to sit under `flutter_animate` (the everyday
+/// declarative layer) and Flutter's implicit `AnimatedX` widgets.
+///
+/// **Infinite/repeating** animations (shimmer, pulse, wiggle) MUST be gated
+/// behind [infiniteMotionEnabled]. That gate:
+///   1. honors the OS "reduce motion" accessibility setting, and
+///   2. collapses loops to a static frame in widget tests, so an unbounded
+///      animation never hangs `pumpAndSettle`.
+/// `test/flutter_test_config.dart` sets [disableInfiniteForTests] = true for
+/// the whole package.
+///
+/// Finite animations (entries, press, count-ups) need no gate — they settle.
+class AppMotion {
+  AppMotion._();
+
+  // ── Durations ──────────────────────────────────────────────────────────
+  /// Press / tap acknowledgement.
+  static const micro = Duration(milliseconds: 120);
+
+  /// Small state changes (chip toggle, icon swap).
+  static const fast = Duration(milliseconds: 200);
+
+  /// Standard entries and `AnimatedSwitcher` crossfades.
+  static const standard = Duration(milliseconds: 250);
+
+  /// Hero reveals and number count-ups.
+  static const emphasized = Duration(milliseconds: 400);
+
+  /// One shimmer sweep across a skeleton.
+  static const shimmerCycle = Duration(milliseconds: 1100);
+
+  /// Per-item delay when staggering a list reveal.
+  static const stagger = Duration(milliseconds: 55);
+
+  // ── Curves ─────────────────────────────────────────────────────────────
+  /// Things appearing / moving into place.
+  static const entry = Curves.easeOutCubic;
+
+  /// Things leaving.
+  static const exit = Curves.easeInCubic;
+
+  /// Default for value/size changes.
+  static const standardCurve = Curves.easeOutQuad;
+
+  /// Press release and small "pops" (slight overshoot).
+  static const springy = Curves.easeOutBack;
+
+  // ── Gate ───────────────────────────────────────────────────────────────
+  /// Flipped true by the test harness (`flutter_test_config.dart`) so
+  /// repeating animations render a single static frame instead of looping.
+  static bool disableInfiniteForTests = false;
+
+  /// True when looping animations should actually run: not under test, and
+  /// the user hasn't asked the OS to reduce motion.
+  static bool infiniteMotionEnabled(BuildContext context) {
+    if (disableInfiniteForTests) return false;
+    final mq = MediaQuery.maybeOf(context);
+    return !(mq?.disableAnimations ?? false);
+  }
+}
+
+/// Wraps [child] in a brief scale-down on press, with an optional [onTap].
+///
+/// The everyday tactile primitive for buttons, cards, and tiles: primary
+/// affordances shrink to [pressedScale] on touch-down and spring back on
+/// release. Purely finite (a single `AnimatedScale`), so it is test-safe and
+/// never gated.
+class PressableScale extends StatefulWidget {
+  final Widget child;
+  final VoidCallback? onTap;
+  final double pressedScale;
+  final HitTestBehavior behavior;
+
+  const PressableScale({
+    super.key,
+    required this.child,
+    this.onTap,
+    this.pressedScale = 0.97,
+    this.behavior = HitTestBehavior.opaque,
+  });
+
+  @override
+  State<PressableScale> createState() => _PressableScaleState();
+}
+
+class _PressableScaleState extends State<PressableScale> {
+  bool _pressed = false;
+
+  void _set(bool v) {
+    if (_pressed != v) setState(() => _pressed = v);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: widget.behavior,
+      onTap: widget.onTap,
+      onTapDown: (_) => _set(true),
+      onTapUp: (_) => _set(false),
+      onTapCancel: () => _set(false),
+      child: AnimatedScale(
+        scale: _pressed ? widget.pressedScale : 1.0,
+        duration: AppMotion.micro,
+        curve: AppMotion.springy,
+        child: widget.child,
+      ),
+    );
+  }
+}

--- a/mobile/lib/design/widgets.dart
+++ b/mobile/lib/design/widgets.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 
 import '../theme.dart';
+import 'motion.dart';
 import 'spacing.dart';
 
 /// Small uppercase-ish caption used above a data block.
@@ -278,8 +280,10 @@ class EmptyState extends StatelessWidget {
 
 /// Loading skeleton — replaces bare CircularProgressIndicator.
 /// Renders N rounded rectangles sized to mirror the content that will resolve
-/// into place. Reduces layout shift on load. Static (no infinite animation) so
-/// widget tests don't hang on `pumpAndSettle`.
+/// into place, reducing layout shift on load. A soft shimmer sweeps across
+/// them to signal "loading, not frozen". The shimmer is gated by
+/// [AppMotion.infiniteMotionEnabled] so it honors reduce-motion and collapses
+/// to a static frame in widget tests (no `pumpAndSettle` hang).
 class SkeletonList extends StatelessWidget {
   final int count;
   final double itemHeight;
@@ -293,18 +297,31 @@ class SkeletonList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final shimmer = AppMotion.infiniteMotionEnabled(context);
     return ListView.separated(
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       itemCount: count,
       separatorBuilder: (_, _) => SizedBox(height: gap),
-      itemBuilder: (_, _) => Container(
-        height: itemHeight,
-        decoration: BoxDecoration(
-          color: BrandColors.line.withValues(alpha: 0.75),
-          borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
-        ),
-      ),
+      itemBuilder: (_, _) {
+        Widget box = Container(
+          key: const Key('skeleton-box'),
+          height: itemHeight,
+          decoration: BoxDecoration(
+            color: BrandColors.line.withValues(alpha: 0.75),
+            borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
+          ),
+        );
+        if (shimmer) {
+          box = box
+              .animate(onPlay: (c) => c.repeat())
+              .shimmer(
+                duration: AppMotion.shimmerCycle,
+                color: BrandColors.surface.withValues(alpha: 0.65),
+              );
+        }
+        return box;
+      },
     );
   }
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -334,6 +334,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_animate:
+    dependency: "direct main"
+    description:
+      name: flutter_animate
+      sha256: "7befe2d3252728afb77aecaaea1dec88a89d35b9b1d2eea6d04479e8af9117b5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -355,6 +363,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  flutter_shaders:
+    dependency: transitive
+    description:
+      name: flutter_shaders
+      sha256: "34794acadd8275d971e02df03afee3dee0f98dbfb8c4837082ad0034f612a3e2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -27,6 +27,9 @@ dependencies:
   # Fonts
   google_fonts: ^6.2.1
 
+  # Motion layer (ADR-0008) — declarative, RTL-safe, tiny.
+  flutter_animate: ^4.5.0
+
   # i18n
   intl: ^0.20.2
 

--- a/mobile/test/design/motion_test.dart
+++ b/mobile/test/design/motion_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:velofit/design/motion.dart';
+import 'package:velofit/design/widgets.dart';
+
+Widget _host(Widget child, {bool reduceMotion = false}) {
+  return MediaQuery(
+    data: MediaQueryData(disableAnimations: reduceMotion),
+    child: MaterialApp(
+      home: Directionality(
+        textDirection: TextDirection.rtl,
+        child: Scaffold(body: child),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('PressableScale', () {
+    testWidgets('renders its child', (tester) async {
+      await tester.pumpWidget(
+        _host(const PressableScale(child: Text('לחץ'))),
+      );
+      expect(find.text('לחץ'), findsOneWidget);
+    });
+
+    testWidgets('invokes onTap when tapped', (tester) async {
+      var taps = 0;
+      await tester.pumpWidget(
+        _host(PressableScale(onTap: () => taps++, child: const Text('לחץ'))),
+      );
+      await tester.tap(find.text('לחץ'));
+      await tester.pumpAndSettle();
+      expect(taps, 1);
+    });
+
+    testWidgets('settles (no infinite animation) so pumpAndSettle returns',
+        (tester) async {
+      await tester.pumpWidget(
+        _host(const PressableScale(child: Text('לחץ'))),
+      );
+      // Would hang if PressableScale ran an unbounded animation.
+      await tester.pumpAndSettle();
+      expect(find.text('לחץ'), findsOneWidget);
+    });
+  });
+
+  group('SkeletonList', () {
+    testWidgets('renders `count` skeleton boxes', (tester) async {
+      await tester.pumpWidget(_host(const SkeletonList(count: 3)));
+      // 3 skeleton containers nested in the list.
+      expect(
+        find.byKey(const Key('skeleton-box')),
+        findsNWidgets(3),
+      );
+    });
+
+    testWidgets('does not hang pumpAndSettle even though it shimmers',
+        (tester) async {
+      // disableInfiniteForTests is set by flutter_test_config.dart, so the
+      // shimmer collapses to a static frame here.
+      await tester.pumpWidget(_host(const SkeletonList(count: 4)));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key('skeleton-box')), findsNWidgets(4));
+    });
+  });
+
+  group('AppMotion gate', () {
+    testWidgets('infiniteMotionEnabled is false under reduce-motion',
+        (tester) async {
+      // Force the test-disable off so we isolate the reduce-motion branch.
+      AppMotion.disableInfiniteForTests = false;
+      addTearDown(() => AppMotion.disableInfiniteForTests = true);
+
+      late bool enabled;
+      await tester.pumpWidget(
+        _host(
+          reduceMotion: true,
+          Builder(builder: (context) {
+            enabled = AppMotion.infiniteMotionEnabled(context);
+            return const SizedBox();
+          }),
+        ),
+      );
+      expect(enabled, isFalse);
+    });
+
+    testWidgets('infiniteMotionEnabled is true when motion allowed',
+        (tester) async {
+      AppMotion.disableInfiniteForTests = false;
+      addTearDown(() => AppMotion.disableInfiniteForTests = true);
+
+      late bool enabled;
+      await tester.pumpWidget(
+        _host(
+          reduceMotion: false,
+          Builder(builder: (context) {
+            enabled = AppMotion.infiniteMotionEnabled(context);
+            return const SizedBox();
+          }),
+        ),
+      );
+      expect(enabled, isTrue);
+    });
+  });
+}

--- a/mobile/test/flutter_test_config.dart
+++ b/mobile/test/flutter_test_config.dart
@@ -1,0 +1,11 @@
+import 'dart:async';
+
+import 'package:velofit/design/motion.dart';
+
+/// Auto-loaded by `flutter test` for every test in this package. Disables
+/// looping animations so shimmer/pulse/wiggle render a static frame and never
+/// hang `pumpAndSettle`. Finite animations still run and settle normally.
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  AppMotion.disableInfiniteForTests = true;
+  await testMain();
+}


### PR DESCRIPTION
First slice of the UI/UX motion overhaul. Audit found the app is static (2/20 screens had any animation), which reads as un-premium despite a solid palette/type system. This lays the base layer.

## What ships
- `AppMotion` tokens (durations 120–400ms, curves, stagger) in `design/motion.dart`
- `PressableScale` press primitive (finite, test-safe)
- **Infinite-motion gate**: `AppMotion.infiniteMotionEnabled` honors OS reduce-motion; `test/flutter_test_config.dart` disables loops package-wide so shimmer/pulse never hang `pumpAndSettle`
- `SkeletonList` now shimmers (gated)
- ADR-0008 + design-system §Motion

## Locked rules honored
No confetti (rule 3), no fl_chart. Motion celebrates within those.

## Tests
147 flutter tests (140→147), analyze clean.