### PR TITLE
feat: staggered entry reveals on main lists

### DIFF
--- a/mobile/lib/design/motion.dart
+++ b/mobile/lib/design/motion.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 
 /// Velofit motion tokens + gate.
 ///
@@ -52,15 +53,45 @@ class AppMotion {
 
   // ── Gate ───────────────────────────────────────────────────────────────
   /// Flipped true by the test harness (`flutter_test_config.dart`) so
-  /// repeating animations render a single static frame instead of looping.
+  /// animations render their final frame instead of playing (loops would hang
+  /// `pumpAndSettle`; entrances/count-ups would add flaky mid-flight frames).
   static bool disableInfiniteForTests = false;
 
-  /// True when looping animations should actually run: not under test, and
-  /// the user hasn't asked the OS to reduce motion.
-  static bool infiniteMotionEnabled(BuildContext context) {
+  /// True when *any* non-essential animation should play (entrances, count-ups,
+  /// loops): not under test, and the user hasn't asked the OS to reduce motion.
+  static bool enabled(BuildContext context) {
     if (disableInfiniteForTests) return false;
     final mq = MediaQuery.maybeOf(context);
     return !(mq?.disableAnimations ?? false);
+  }
+
+  /// Alias kept for call sites that specifically gate looping animations.
+  static bool infiniteMotionEnabled(BuildContext context) => enabled(context);
+}
+
+/// Staggered entrance: fades + lifts [child] into place, delayed by its
+/// position so a list reveals top-to-bottom. Finite, but skipped entirely when
+/// motion is off (reduce-motion / tests) — returns the child untouched so
+/// hit-testing and `find` work without a `pumpAndSettle`.
+class Reveal extends StatelessWidget {
+  final Widget child;
+  final int index;
+  final double offsetY;
+
+  const Reveal(this.child, {super.key, this.index = 0, this.offsetY = 0.08});
+
+  @override
+  Widget build(BuildContext context) {
+    if (!AppMotion.enabled(context)) return child;
+    return child
+        .animate(delay: AppMotion.stagger * index)
+        .fadeIn(duration: AppMotion.standard, curve: AppMotion.entry)
+        .slideY(
+          begin: offsetY,
+          end: 0,
+          duration: AppMotion.standard,
+          curve: AppMotion.entry,
+        );
   }
 }
 

--- a/mobile/lib/features/coach/coach_trainees_screen.dart
+++ b/mobile/lib/features/coach/coach_trainees_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../design/motion.dart';
 import '../../design/spacing.dart';
 import '../../design/widgets.dart';
 import '../../theme.dart';
@@ -178,7 +179,8 @@ class _CoachTraineesScreenState extends ConsumerState<CoachTraineesScreen> {
                     : ListView.separated(
                         itemCount: filtered.length,
                         separatorBuilder: (_, _) => const Divider(height: 1),
-                        itemBuilder: (_, i) => _TraineeRow(trainee: filtered[i]),
+                        itemBuilder: (_, i) =>
+                            Reveal(_TraineeRow(trainee: filtered[i]), index: i),
                       ),
               ),
             ],

--- a/mobile/lib/features/coach/coach_week_screen.dart
+++ b/mobile/lib/features/coach/coach_week_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../design/motion.dart';
 import '../../design/spacing.dart';
 import '../../design/widgets.dart';
 import '../../theme.dart';
@@ -200,7 +201,10 @@ class _CoachWeekScreenState extends ConsumerState<CoachWeekScreen> {
                   itemBuilder: (_, i) {
                     final slot = slots[i];
                     final slotBookings = bySlot[slot.id] ?? const [];
-                    return _CoachSlotTile(slot: slot, bookings: slotBookings);
+                    return Reveal(
+                      _CoachSlotTile(slot: slot, bookings: slotBookings),
+                      index: i,
+                    );
                   },
                 );
               },

--- a/mobile/lib/features/slots/home_screen.dart
+++ b/mobile/lib/features/slots/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../design/motion.dart';
 import '../../design/spacing.dart';
 import '../../design/widgets.dart';
 import '../../theme.dart';
@@ -178,13 +179,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                       return Column(
                         key: const Key('slots-list'),
                         children: [
-                          for (final slot in slots)
-                            _SlotTile(
-                              slot: slot,
-                              booked: bookedSlotIds.contains(slot.id),
-                              onTap: bookedSlotIds.contains(slot.id)
-                                  ? null
-                                  : () => _openBookingDialog(slot),
+                          for (var i = 0; i < slots.length; i++)
+                            Reveal(
+                              _SlotTile(
+                                slot: slots[i],
+                                booked: bookedSlotIds.contains(slots[i].id),
+                                onTap: bookedSlotIds.contains(slots[i].id)
+                                    ? null
+                                    : () => _openBookingDialog(slots[i]),
+                              ),
+                              index: i,
                             ),
                           const SizedBox(height: 24),
                         ],

--- a/mobile/test/design/reveal_test.dart
+++ b/mobile/test/design/reveal_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:velofit/design/motion.dart';
+
+Widget _host(Widget child, {bool reduceMotion = false}) => MediaQuery(
+      data: MediaQueryData(disableAnimations: reduceMotion),
+      child: MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.rtl,
+          child: Scaffold(body: child),
+        ),
+      ),
+    );
+
+void main() {
+  group('Reveal', () {
+    testWidgets('renders its child', (tester) async {
+      await tester.pumpWidget(
+        _host(const Reveal(Text('שורה'), index: 2)),
+      );
+      expect(find.text('שורה'), findsOneWidget);
+    });
+
+    testWidgets('returns child untouched (no animation) in tests', (tester) async {
+      // disableInfiniteForTests is set by flutter_test_config — the child is
+      // visible and tappable on the first frame, no pumpAndSettle needed.
+      var taps = 0;
+      await tester.pumpWidget(
+        _host(Reveal(
+          GestureDetector(onTap: () => taps++, child: const Text('שורה')),
+          index: 5,
+        )),
+      );
+      await tester.tap(find.text('שורה'));
+      await tester.pump();
+      expect(taps, 1);
+    });
+
+    testWidgets('plays a finite entrance when motion is enabled (settles)',
+        (tester) async {
+      AppMotion.disableInfiniteForTests = false;
+      addTearDown(() => AppMotion.disableInfiniteForTests = true);
+
+      await tester.pumpWidget(
+        _host(const Reveal(Text('שורה'), index: 3)),
+      );
+      // Pump past the stagger delay (a Timer) so the entrance starts, then let
+      // it settle. Would hang here if the entrance looped.
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pumpAndSettle();
+      expect(find.text('שורה'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Slice 2 of the motion overhaul. Lists now fade+lift in top-to-bottom instead of snapping.

## What ships
- `Reveal` primitive (flutter_animate `fadeIn` + `slideY`, per-index stagger). Gated by `AppMotion.enabled` — when motion is off (reduce-motion / tests) it returns the child untouched, so hit-testing and `find` work with no `pumpAndSettle` and existing screen tests are unaffected.
- Generalized `AppMotion.enabled` gate (`infiniteMotionEnabled` delegates to it).
- Applied to: coach trainee list, coach week slot list, trainee home available-slots.

## Tests
152 → 155 flutter tests, analyze clean.