### PR TITLE
feat: micro-interactions — press-scale, badge pop, countdown pulse

### DIFF
--- a/mobile/lib/design/motion.dart
+++ b/mobile/lib/design/motion.dart
@@ -95,12 +95,17 @@ class Reveal extends StatelessWidget {
   }
 }
 
-/// Wraps [child] in a brief scale-down on press, with an optional [onTap].
+/// Wraps [child] in a brief scale-down on press.
 ///
 /// The everyday tactile primitive for buttons, cards, and tiles: primary
 /// affordances shrink to [pressedScale] on touch-down and spring back on
 /// release. Purely finite (a single `AnimatedScale`), so it is test-safe and
 /// never gated.
+///
+/// Press tracking uses a [Listener], which does NOT compete in the gesture
+/// arena — so it can decorate a widget that already has its own `InkWell` /
+/// `GestureDetector` without stealing taps. Pass [onTap] only when this widget
+/// should own the tap itself.
 class PressableScale extends StatefulWidget {
   final Widget child;
   final VoidCallback? onTap;
@@ -128,12 +133,10 @@ class _PressableScaleState extends State<PressableScale> {
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      behavior: widget.behavior,
-      onTap: widget.onTap,
-      onTapDown: (_) => _set(true),
-      onTapUp: (_) => _set(false),
-      onTapCancel: () => _set(false),
+    Widget result = Listener(
+      onPointerDown: (_) => _set(true),
+      onPointerUp: (_) => _set(false),
+      onPointerCancel: (_) => _set(false),
       child: AnimatedScale(
         scale: _pressed ? widget.pressedScale : 1.0,
         duration: AppMotion.micro,
@@ -141,5 +144,13 @@ class _PressableScaleState extends State<PressableScale> {
         child: widget.child,
       ),
     );
+    if (widget.onTap != null) {
+      result = GestureDetector(
+        behavior: widget.behavior,
+        onTap: widget.onTap,
+        child: result,
+      );
+    }
+    return result;
   }
 }

--- a/mobile/lib/features/coach/coach_week_screen.dart
+++ b/mobile/lib/features/coach/coach_week_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../design/motion.dart';
@@ -406,27 +407,50 @@ class _InboxRow extends StatelessWidget {
             Expanded(
               child: Text(label, style: theme.textTheme.bodyMedium),
             ),
-            Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 8, vertical: 1),
-              decoration: BoxDecoration(
-                color: BrandColors.orange,
-                borderRadius: BorderRadius.circular(AppSpacing.radiusPill),
-              ),
-              child: Text(
-                '$count',
-                style: theme.textTheme.labelMedium?.copyWith(
-                  color: Colors.white,
-                  fontWeight: FontWeight.w800,
-                ),
-              ),
-            ),
+            _CountBadge(count: count),
             const SizedBox(width: AppSpacing.xs),
             const Icon(Icons.chevron_left, size: 18, color: BrandColors.inkMuted),
           ],
         ),
       ),
     );
+  }
+}
+
+/// Orange count pill that pops (scales in) whenever [count] changes — a small
+/// "you have new work" cue. Finite + gated, so it's static under
+/// reduce-motion / tests.
+class _CountBadge extends StatelessWidget {
+  final int count;
+  const _CountBadge({required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final badge = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 1),
+      decoration: BoxDecoration(
+        color: BrandColors.orange,
+        borderRadius: BorderRadius.circular(AppSpacing.radiusPill),
+      ),
+      child: Text(
+        '$count',
+        style: theme.textTheme.labelMedium?.copyWith(
+          color: Colors.white,
+          fontWeight: FontWeight.w800,
+        ),
+      ),
+    );
+    if (!AppMotion.enabled(context)) return badge;
+    // Re-keying on count replays the pop when the number changes.
+    return badge
+        .animate(key: ValueKey(count))
+        .scale(
+          begin: const Offset(0.6, 0.6),
+          end: const Offset(1, 1),
+          duration: AppMotion.standard,
+          curve: AppMotion.springy,
+        );
   }
 }
 

--- a/mobile/lib/features/slots/home_screen.dart
+++ b/mobile/lib/features/slots/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_animate/flutter_animate.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../design/motion.dart';
@@ -320,7 +321,7 @@ class _NextSessionPill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
+    final pill = Container(
       padding: const EdgeInsets.symmetric(
         horizontal: AppSpacing.sm,
         vertical: AppSpacing.xs,
@@ -344,6 +345,17 @@ class _NextSessionPill extends StatelessWidget {
         ],
       ),
     );
+    if (!AppMotion.infiniteMotionEnabled(context)) return pill;
+    // Gentle breathing pulse draws the eye to the next session without
+    // shouting. Gated — static under reduce-motion / tests.
+    return pill
+        .animate(onPlay: (c) => c.repeat(reverse: true))
+        .scaleXY(
+          begin: 1.0,
+          end: 1.03,
+          duration: const Duration(milliseconds: 1400),
+          curve: Curves.easeInOut,
+        );
   }
 }
 
@@ -393,7 +405,8 @@ class _QuickActionChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Expanded(
-      child: InkWell(
+      child: PressableScale(
+        child: InkWell(
         onTap: onTap,
         borderRadius: BorderRadius.circular(AppSpacing.radiusMd),
         child: Container(
@@ -420,6 +433,7 @@ class _QuickActionChip extends StatelessWidget {
             ],
           ),
         ),
+      ),
       ),
     );
   }
@@ -971,7 +985,7 @@ class _SlotTile extends StatelessWidget {
             ? scheme.outline
             : scheme.secondary;
 
-    return Card(
+    final card = Card(
       key: Key('slot-${slot.startTime}'),
       child: InkWell(
         onTap: available ? onTap : null,
@@ -1013,5 +1027,7 @@ class _SlotTile extends StatelessWidget {
         ),
       ),
     );
+    // Press feedback only where the tile is actionable.
+    return available ? PressableScale(child: card) : card;
   }
 }

--- a/mobile/test/design/motion_test.dart
+++ b/mobile/test/design/motion_test.dart
@@ -43,6 +43,22 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text('לחץ'), findsOneWidget);
     });
+
+    testWidgets('as a decorator (no onTap) it does not steal the inner tap',
+        (tester) async {
+      var inner = 0;
+      await tester.pumpWidget(
+        _host(PressableScale(
+          child: GestureDetector(
+            onTap: () => inner++,
+            child: const Text('לחץ'),
+          ),
+        )),
+      );
+      await tester.tap(find.text('לחץ'));
+      await tester.pumpAndSettle();
+      expect(inner, 1); // Listener-based press doesn't enter the gesture arena
+    });
   });
 
   group('SkeletonList', () {


### PR DESCRIPTION
Slice 4 (final) of the motion overhaul. The small tactile cues that make the UI feel responsive.

## What ships
- `PressableScale` reworked to track press via `Listener` (no gesture-arena conflict) so it decorates an existing `InkWell`/`GestureDetector` without stealing its tap. Regression test added.
- Applied to home quick-action chips + actionable slot tiles.
- Coach inbox count badge **pops** (scale-in, re-keyed on count change) — finite, gated.
- Next-session pill gentle **breathing pulse** — infinite, gated.

## Tests
158 → 159 flutter tests, analyze clean. Gating keeps everything static under reduce-motion / tests.