### PR TITLE
feat(dev): native Postgres local dev path (no Docker)

### DIFF
--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -1,0 +1,64 @@
+# Local dev on native Postgres (no Docker)
+
+Fast local iteration without the slow cloud Supabase round-trip. Selected by
+`DB_DRIVER=pg` in `.env.development.local`, which Next.js loads for `npm run dev`
+(overriding `.env.local`). **Delete `.env.development.local` to revert to cloud
+Supabase** — no code change needed.
+
+> Auth/Storage note: this path replaces Supabase Auth (GoTrue) with a local
+> HS256 dev token (`/api/dev/login`) and has **no Storage service** — progress
+> photos (#61) are unavailable locally. Everything else (booking, progress,
+> notes, coach flows) runs on native Postgres.
+
+## One-time setup (done)
+
+- Postgres 18 installed via scoop: `scoop install postgresql`
+- DB created: `createdb -h localhost -U postgres velofit_dev`
+- `.env.development.local` holds `DB_DRIVER=pg`, `DATABASE_URL`, `DEV_JWT_SECRET`
+
+## Start / stop Postgres
+
+The scoop install does NOT register a Windows service, so start it per machine
+boot (it does not survive a reboot):
+
+```powershell
+$PG = "$env:USERPROFILE\scoop\apps\postgresql\current"
+& "$PG\bin\pg_ctl.exe" -D "$PG\data" -l "$PG\data\logfile" start   # start
+& "$PG\bin\pg_ctl.exe" -D "$PG\data" stop                          # stop
+& "$PG\bin\pg_isready.exe" -h localhost -p 5432                    # check
+```
+
+## Reset schema + seed
+
+```bash
+npm run db:pg:reset   # drop + replay the 18 migrations (skips Storage bucket)
+npm run db:pg:seed    # coach + 8 trainees + slots for this + next week
+```
+
+`db:pg:reset` installs `auth`/`storage` stubs (`scripts/pg/bootstrap.sql`) so the
+Supabase migrations apply against a bare Postgres. The pool connects as DB owner,
+so RLS is bypassed (same as the cloud service-role key).
+
+## Run the app
+
+```bash
+npm run dev   # http://localhost:3000 — loads .env.development.local (DB_DRIVER=pg)
+```
+
+## Dev login (no GoTrue)
+
+`POST /api/dev/login` with `{ email, password }` where `password` = `DEV_PASSWORD`
+(from `.env.local`). Returns `{ token, user }`. Send `Authorization: Bearer <token>`
+on subsequent requests. Seeded logins: `dev.coach@example.com` (coach) and the
+8 `*.example.com` trainees.
+
+## Architecture
+
+`DB_DRIVER=pg` flips three things, all behind the existing seams:
+- `getJwtSession` verifies the dev HS256 token instead of calling GoTrue.
+- The container (`services/index.ts`) builds `Pg{Booking,Progress,Auth}` stores.
+- Direct repos/routes (`profile-repo`, `coach-info-repo`, `notes-repo`,
+  `trainee-invite`, `trainee-profile-repo`, `me`, `me/intro`, approve, reject)
+  branch on `isPgDriver()`.
+
+Cloud Supabase remains the default when `DB_DRIVER` is unset.

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -52,6 +52,26 @@ npm run dev   # http://localhost:3000 — loads .env.development.local (DB_DRIVE
 on subsequent requests. Seeded logins: `dev.coach@example.com` (coach) and the
 8 `*.example.com` trainees.
 
+## Mobile (Flutter) against local pg
+
+`mobile/dev-env.json` sets `PG_DEV: "true"` and `API_BASE_URL` to the local
+backend (`http://10.0.2.2:3000` for the Android emulator; use
+`http://localhost:3000` for iOS sim). With `PG_DEV` on, the app skips Supabase
+GoTrue entirely: the DEV-mode quick-login panel calls `/api/dev/login`, stores
+the returned HS256 token in `devSessionProvider`, and `AuthedHttpClient` sends
+it as the Bearer on every request. `auth_gate` keys off the dev session instead
+of the Supabase stream.
+
+```bash
+cd mobile && flutter run --dart-define-from-file=dev-env.json
+```
+
+Make sure the backend (`npm run dev`) and Postgres are running first. To go
+back to cloud auth, set `PG_DEV` to `"false"` (or remove it) in `dev-env.json`.
+
+Known gap: sign-out in `PG_DEV` mode is not yet wired to clear the dev session
+(hot-restart to switch users); full wiring is a follow-up.
+
 ## Architecture
 
 `DB_DRIVER=pg` flips three things, all behind the existing seams:

--- a/mobile/lib/config/env.dart
+++ b/mobile/lib/config/env.dart
@@ -8,6 +8,10 @@ class Env {
     defaultValue: 'http://localhost:3000',
   );
   static const devMode = bool.fromEnvironment('DEV_MODE');
+
+  /// When true, auth goes through the backend's /api/dev/login (native-Postgres
+  /// dev path, no Supabase GoTrue). See docs/LOCAL_DEV.md.
+  static const pgDev = bool.fromEnvironment('PG_DEV');
   static const devPassword = String.fromEnvironment('DEV_PASSWORD');
   static const devTraineeEmails = String.fromEnvironment('DEV_TRAINEE_EMAILS');
   static const devTraineeNames = String.fromEnvironment('DEV_TRAINEE_NAMES');

--- a/mobile/lib/features/auth/auth_gate.dart
+++ b/mobile/lib/features/auth/auth_gate.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
+import '../../config/env.dart';
 import '../profile/profile_repository.dart';
+import 'dev_session.dart';
 import 'login_screen.dart';
 import 'role_router.dart';
 
@@ -55,6 +57,12 @@ class _AuthGateState extends ConsumerState<AuthGate> {
 
   @override
   Widget build(BuildContext context) {
+    // Native-Postgres dev path: auth state lives in devSessionProvider, not
+    // Supabase. The Supabase listener stays wired but is dormant.
+    if (Env.pgDev) {
+      final dev = ref.watch(devSessionProvider);
+      return dev == null ? const LoginScreen() : const RoleRouter();
+    }
     return _session == null ? const LoginScreen() : const RoleRouter();
   }
 }

--- a/mobile/lib/features/auth/dev_session.dart
+++ b/mobile/lib/features/auth/dev_session.dart
@@ -1,0 +1,48 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../config/env.dart';
+
+/// A dev session minted by the backend's /api/dev/login (native-Postgres dev
+/// path, no Supabase GoTrue). Holds the HS256 bearer token used by
+/// AuthedHttpClient and the resolved user.
+class DevSession {
+  final String token;
+  final String userId;
+  final String email;
+  final String role;
+
+  const DevSession({
+    required this.token,
+    required this.userId,
+    required this.email,
+    required this.role,
+  });
+}
+
+class DevSessionNotifier extends Notifier<DevSession?> {
+  @override
+  DevSession? build() => null;
+
+  /// Exchanges email + dev password for a token via the backend.
+  Future<void> login(String email, String password) async {
+    final dio = Dio(BaseOptions(baseUrl: Env.apiBaseUrl));
+    final res = await dio.post<Map<String, dynamic>>(
+      '/api/dev/login',
+      data: {'email': email, 'password': password},
+    );
+    final data = res.data!;
+    final user = data['user'] as Map<String, dynamic>;
+    state = DevSession(
+      token: data['token'] as String,
+      userId: user['id'] as String,
+      email: user['email'] as String,
+      role: user['role'] as String,
+    );
+  }
+
+  void logout() => state = null;
+}
+
+final devSessionProvider =
+    NotifierProvider<DevSessionNotifier, DevSession?>(DevSessionNotifier.new);

--- a/mobile/lib/features/dev/dev_login_panel.dart
+++ b/mobile/lib/features/dev/dev_login_panel.dart
@@ -3,7 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../config/env.dart';
 import '../auth/auth_repository.dart';
+import '../auth/dev_session.dart';
 import '../auth/role_router.dart';
+import '../profile/profile_repository.dart';
 
 class DevAccount {
   final String email;
@@ -74,10 +76,17 @@ class DevLoginPanel extends ConsumerWidget {
               child: OutlinedButton(
                 key: Key('dev-login-${acc.email}'),
                 onPressed: () async {
-                  await ref.read(authRepositoryProvider).signInWithPassword(
-                        email: acc.email,
-                        password: password,
-                      );
+                  if (Env.pgDev) {
+                    await ref
+                        .read(devSessionProvider.notifier)
+                        .login(acc.email, password);
+                    ref.invalidate(profileProvider);
+                  } else {
+                    await ref.read(authRepositoryProvider).signInWithPassword(
+                          email: acc.email,
+                          password: password,
+                        );
+                  }
                   if (!context.mounted) return;
                   Navigator.of(context).pushReplacement(
                     MaterialPageRoute(builder: (_) => const RoleRouter()),

--- a/mobile/lib/utils/authed_http_client.dart
+++ b/mobile/lib/utils/authed_http_client.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../config/env.dart';
+import '../features/auth/dev_session.dart';
 
 /// Structured backend error matching the codes returned by the
 /// /lib/auth/require helpers in the Next.js backend (RFC #43).
@@ -24,10 +25,15 @@ class ApiException implements Exception {
 class AuthedHttpClient {
   final Dio _dio;
   final SupabaseClient _supabase;
+  final String? Function()? _devToken;
 
-  AuthedHttpClient(this._dio, this._supabase);
+  AuthedHttpClient(this._dio, this._supabase, {this._devToken});
 
   String _requireJwt() {
+    // Native-Postgres dev path: a backend-minted token takes precedence over
+    // the (unused) Supabase session.
+    final dev = _devToken?.call();
+    if (dev != null) return dev;
     final jwt = _supabase.auth.currentSession?.accessToken;
     if (jwt == null) {
       throw const ApiException('UNAUTHENTICATED', 401);
@@ -114,5 +120,9 @@ final dioProvider = Provider<Dio>((ref) {
 });
 
 final authedHttpProvider = Provider<AuthedHttpClient>((ref) {
-  return AuthedHttpClient(ref.watch(dioProvider), Supabase.instance.client);
+  return AuthedHttpClient(
+    ref.watch(dioProvider),
+    Supabase.instance.client,
+    devToken: () => ref.read(devSessionProvider)?.token,
+  );
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,17 @@
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "googleapis": "^171.4.0",
+        "jsonwebtoken": "^9.0.3",
         "next": "^16.2.3",
+        "pg": "^8.21.0",
         "react": "19.2.4",
         "react-dom": "19.2.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^20",
+        "@types/pg": "^8.20.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "dotenv": "^17.4.2",
@@ -2662,6 +2666,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -2669,6 +2691,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
       }
     },
     "node_modules/@types/react": {
@@ -6304,6 +6338,40 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -6662,11 +6730,53 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -7224,6 +7334,96 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7280,6 +7480,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -7892,6 +8131,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {
@@ -9109,6 +9357,15 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "db:pg:reset": "tsx scripts/pg/reset.ts",
+    "db:pg:seed": "tsx scripts/pg/seed.ts"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.2",
@@ -16,13 +18,17 @@
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "googleapis": "^171.4.0",
+    "jsonwebtoken": "^9.0.3",
     "next": "^16.2.3",
+    "pg": "^8.21.0",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^20",
+    "@types/pg": "^8.20.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "dotenv": "^17.4.2",

--- a/scripts/pg/bootstrap.sql
+++ b/scripts/pg/bootstrap.sql
@@ -1,0 +1,24 @@
+-- Dev-only stubs so the Supabase migrations apply against a bare local
+-- Postgres (no GoTrue, no Storage service). The dev server connects as the DB
+-- owner, which bypasses RLS — so these objects only need to EXIST for the
+-- migration RLS policies to compile; they are never relied on for enforcement.
+
+create schema if not exists auth;
+
+-- Minimal stand-in for Supabase's auth.users (profiles FK to it).
+create table if not exists auth.users (
+  id    uuid primary key default gen_random_uuid(),
+  email text unique
+);
+
+-- auth.uid() / auth.role(): read from a GUC if a request set one, else safe
+-- defaults. Owner connection bypasses RLS, so the return value is immaterial.
+create or replace function auth.uid() returns uuid
+  language sql stable as $$
+    select nullif(current_setting('request.jwt.claim.sub', true), '')::uuid
+  $$;
+
+create or replace function auth.role() returns text
+  language sql stable as $$
+    select coalesce(nullif(current_setting('request.jwt.claim.role', true), ''), 'authenticated')
+  $$;

--- a/scripts/pg/reset.ts
+++ b/scripts/pg/reset.ts
@@ -1,0 +1,73 @@
+/**
+ * Reset the local dev Postgres to a clean schema: drop public/auth/storage,
+ * recreate, install dev stubs, then replay the Supabase migrations in order.
+ *
+ * Skips 00019 (Storage bucket) — there is no Storage service locally and
+ * progress photos (#61) aren't built yet.
+ *
+ * Requires DATABASE_URL (from .env.development.local). Usage:
+ *   npx tsx scripts/pg/reset.ts
+ */
+import * as dotenv from "dotenv";
+import path from "path";
+import fs from "fs";
+import { getPgPool, closePgPool } from "../../src/lib/pg/client";
+
+dotenv.config({ path: path.resolve(__dirname, "../../.env.local") });
+dotenv.config({
+  path: path.resolve(__dirname, "../../.env.development.local"),
+  override: true,
+});
+
+const MIGRATIONS_DIR = path.resolve(__dirname, "../../supabase/migrations");
+const BOOTSTRAP = path.resolve(__dirname, "./bootstrap.sql");
+// Storage-only migration — no Storage service locally.
+const SKIP = new Set(["00019_phase19_progress_photos_bucket.sql"]);
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error("DATABASE_URL is required (set it in .env.development.local).");
+    process.exit(1);
+  }
+  const pool = getPgPool();
+
+  console.log("Dropping & recreating schemas…");
+  await pool.query(`
+    drop schema if exists storage cascade;
+    drop schema if exists auth cascade;
+    drop schema if exists public cascade;
+    create schema public;
+  `);
+
+  console.log("Installing dev stubs (auth schema)…");
+  await pool.query(fs.readFileSync(BOOTSTRAP, "utf8"));
+
+  const files = fs
+    .readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+
+  for (const file of files) {
+    if (SKIP.has(file)) {
+      console.log(`  skip ${file} (storage)`);
+      continue;
+    }
+    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, file), "utf8");
+    try {
+      await pool.query(sql);
+      console.log(`  ✓ ${file}`);
+    } catch (err) {
+      console.error(`  ✗ ${file}\n`, err);
+      throw err;
+    }
+  }
+
+  console.log("Local Postgres schema ready.");
+  await closePgPool();
+}
+
+main().catch(async (e) => {
+  console.error(e);
+  await closePgPool();
+  process.exit(1);
+});

--- a/scripts/pg/seed.ts
+++ b/scripts/pg/seed.ts
@@ -1,0 +1,122 @@
+/**
+ * Seed the local dev Postgres with a coach, trainees, and slots for the
+ * current + next week. Mirrors scripts/seed.ts but writes directly to pg
+ * (no Supabase Admin API). Idempotent via ON CONFLICT.
+ *
+ * Reads DEV_* from .env.local (+ DATABASE_URL from .env.development.local).
+ * Usage: npm run db:pg:seed
+ */
+import * as dotenv from "dotenv";
+import path from "path";
+import { randomUUID } from "crypto";
+import { getPgPool, closePgPool } from "../../src/lib/pg/client";
+
+dotenv.config({ path: path.resolve(__dirname, "../../.env.local") });
+dotenv.config({
+  path: path.resolve(__dirname, "../../.env.development.local"),
+  override: true,
+});
+
+const COACH_EMAIL = process.env.DEV_COACH_EMAIL!;
+const COACH_NAME = process.env.DEV_COACH_NAME!;
+const TRAINEE_EMAILS = (process.env.DEV_TRAINEE_EMAILS ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+const TRAINEE_NAMES = (process.env.DEV_TRAINEE_NAMES ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+
+if (!COACH_EMAIL || !COACH_NAME) {
+  console.error("Missing DEV_COACH_EMAIL / DEV_COACH_NAME");
+  process.exit(1);
+}
+if (TRAINEE_EMAILS.length !== TRAINEE_NAMES.length) {
+  console.error(`DEV_TRAINEE_EMAILS (${TRAINEE_EMAILS.length}) and DEV_TRAINEE_NAMES (${TRAINEE_NAMES.length}) must match`);
+  process.exit(1);
+}
+
+const pool = getPgPool();
+
+/** Insert (or find) an auth.users row by email; returns its id. */
+async function ensureUser(email: string): Promise<string> {
+  const { rows } = await pool.query<{ id: string }>(
+    `insert into auth.users (id, email) values ($1, $2)
+       on conflict (email) do update set email = excluded.email
+       returning id`,
+    [randomUUID(), email],
+  );
+  return rows[0].id;
+}
+
+async function upsertProfile(id: string, email: string, name: string, role: "coach" | "trainee") {
+  await pool.query(
+    `insert into profiles (id, email, name, role, is_active, status)
+       values ($1, $2, $3, $4, true, 'active')
+       on conflict (id) do update
+         set email = excluded.email, name = excluded.name, role = excluded.role`,
+    [id, email, name, role],
+  );
+}
+
+function getWeekStart(): string {
+  const todayIL = new Date().toLocaleDateString("en-CA", { timeZone: "Asia/Jerusalem" });
+  const [y, m, d] = todayIL.split("-").map(Number);
+  const local = new Date(y, m - 1, d, 12);
+  local.setDate(local.getDate() - local.getDay());
+  return `${local.getFullYear()}-${String(local.getMonth() + 1).padStart(2, "0")}-${String(local.getDate()).padStart(2, "0")}`;
+}
+
+function dateForDay(weekStart: string, dayOffset: number): string {
+  const [y, m, d] = weekStart.split("-").map(Number);
+  const dt = new Date(y, m - 1, d + dayOffset, 12);
+  return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, "0")}-${String(dt.getDate()).padStart(2, "0")}`;
+}
+
+async function seedSlots(): Promise<number> {
+  const weekStart = getWeekStart();
+  const hours = ["06:00", "07:00", "08:00", "09:00", "10:00", "11:00", "14:00", "15:00", "16:00", "17:00", "18:00", "19:00", "20:00"];
+  const values: string[] = [];
+  const params: unknown[] = [];
+  let n = 0;
+  for (const ws of [weekStart, dateForDay(weekStart, 7)]) {
+    for (let day = 0; day <= 5; day++) {
+      const date = dateForDay(ws, day);
+      for (const time of hours) {
+        values.push(`($${++n}, $${++n}, 2, false)`);
+        params.push(date, time);
+      }
+    }
+  }
+  await pool.query(
+    `insert into slots (date, start_time, capacity, lockout_override)
+       values ${values.join(", ")}
+       on conflict (date, start_time) do nothing`,
+    params,
+  );
+  return params.length / 2;
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error("DATABASE_URL is required (set it in .env.development.local).");
+    process.exit(1);
+  }
+  console.log(`Seeding ${process.env.DATABASE_URL}\n`);
+
+  const coachId = await ensureUser(COACH_EMAIL);
+  await upsertProfile(coachId, COACH_EMAIL, COACH_NAME, "coach");
+  console.log(`Coach: ${COACH_NAME} <${COACH_EMAIL}>`);
+
+  for (let i = 0; i < TRAINEE_EMAILS.length; i++) {
+    const id = await ensureUser(TRAINEE_EMAILS[i]);
+    await upsertProfile(id, TRAINEE_EMAILS[i], TRAINEE_NAMES[i], "trainee");
+    console.log(`  Trainee: ${TRAINEE_NAMES[i]} <${TRAINEE_EMAILS[i]}>`);
+  }
+
+  const slotCount = await seedSlots();
+  console.log(`\nSlots: ${slotCount} for current + next week`);
+  console.log("Done.");
+  await closePgPool();
+}
+
+main().catch(async (err) => {
+  console.error("Seed failed:", err);
+  await closePgPool();
+  process.exit(1);
+});

--- a/src/app/api/admin/trainees/[id]/approve/route.ts
+++ b/src/app/api/admin/trainees/[id]/approve/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { requireCoach } from "@/lib/auth/require";
 import { loadProfile } from "@/lib/auth/profile-repo";
+import { isPgDriver, pgQuery } from "@/lib/pg/client";
 
 function admin() {
   return createClient(
@@ -37,6 +38,11 @@ export async function POST(
       { error: "INTRO_MISSING", message: "Trainee has not submitted intro yet" },
       { status: 409 }
     );
+  }
+
+  if (isPgDriver()) {
+    await pgQuery("update profiles set status = 'active' where id = $1", [id]);
+    return NextResponse.json({ ok: true });
   }
 
   const { error } = await admin()

--- a/src/app/api/admin/trainees/[id]/reject/route.ts
+++ b/src/app/api/admin/trainees/[id]/reject/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { requireCoach } from "@/lib/auth/require";
 import { loadProfile } from "@/lib/auth/profile-repo";
+import { isPgDriver, pgQuery } from "@/lib/pg/client";
 
 function admin() {
   return createClient(
@@ -31,6 +32,11 @@ export async function POST(
       { error: "NOT_PENDING", message: `status is ${target.status}` },
       { status: 409 }
     );
+  }
+
+  if (isPgDriver()) {
+    await pgQuery("update profiles set status = 'rejected' where id = $1", [id]);
+    return NextResponse.json({ ok: true });
   }
 
   const { error } = await admin()

--- a/src/app/api/dev/login/route.ts
+++ b/src/app/api/dev/login/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isPgDriver, pgQuery } from "@/lib/pg/client";
+import { signDevToken } from "@/lib/pg/dev-auth";
+
+/**
+ * Dev-only login for the native-Postgres path (no GoTrue). Exchanges
+ * email + DEV_PASSWORD for an HS256 token the rest of the app accepts as a
+ * Bearer credential. Disabled (404) unless `DB_DRIVER=pg`.
+ */
+export async function POST(req: NextRequest) {
+  if (!isPgDriver()) {
+    return NextResponse.json({ error: "NOT_FOUND" }, { status: 404 });
+  }
+
+  let body: { email?: string; password?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "BAD_REQUEST" }, { status: 400 });
+  }
+
+  const { email, password } = body;
+  if (!email || !password) {
+    return NextResponse.json({ error: "MISSING_CREDENTIALS" }, { status: 400 });
+  }
+  if (password !== process.env.DEV_PASSWORD) {
+    return NextResponse.json({ error: "INVALID_CREDENTIALS" }, { status: 401 });
+  }
+
+  const rows = await pgQuery<{ id: string; email: string; role: string }>(
+    "select id, email, role from profiles where email = $1 limit 1",
+    [email],
+  );
+  if (rows.length === 0) {
+    return NextResponse.json({ error: "USER_NOT_FOUND" }, { status: 404 });
+  }
+
+  const user = rows[0];
+  const token = signDevToken({ sub: user.id, email: user.email, role: user.role });
+  return NextResponse.json({ token, user });
+}

--- a/src/app/api/me/intro/route.ts
+++ b/src/app/api/me/intro/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { requirePendingTrainee } from "@/lib/auth/require";
+import { isPgDriver, pgQuery } from "@/lib/pg/client";
 
 const E164 = /^\+\d{8,15}$/;
 
@@ -36,6 +37,17 @@ export async function POST(request: NextRequest) {
       { error: "INTRO_TOO_SHORT", message: "introText must be at least 10 chars" },
       { status: 400 }
     );
+  }
+
+  if (isPgDriver()) {
+    await pgQuery(
+      `insert into trainee_profile (id, phone, intro_text, updated_at)
+         values ($1, $2, $3, now())
+         on conflict (id) do update set
+           phone = excluded.phone, intro_text = excluded.intro_text, updated_at = now()`,
+      [r.trainee.userId, body.phone, introText],
+    );
+    return NextResponse.json({ ok: true });
   }
 
   const { error } = await admin()

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { getJwtSession } from "@/lib/services/jwt-session";
 import { loadProfile, createProfile } from "@/lib/auth/profile-repo";
+import { isPgDriver, pgQuery } from "@/lib/pg/client";
 
 function coachEmails(): string[] {
   return (process.env.COACH_EMAIL ?? "")
@@ -20,6 +21,10 @@ async function provisionSelfSignup(
   email: string,
   status: "active" | "pending"
 ): Promise<void> {
+  if (isPgDriver()) {
+    await pgQuery("update profiles set status = $1 where id = $2", [status, userId]);
+    return;
+  }
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) return;

--- a/src/lib/auth/profile-repo.ts
+++ b/src/lib/auth/profile-repo.ts
@@ -1,4 +1,5 @@
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { isPgDriver, pgQuery } from "@/lib/pg/client";
 
 export type Profile = {
   userId: string;
@@ -19,7 +20,68 @@ function admin(): SupabaseClient {
   );
 }
 
+function statusOf(row: { status?: unknown; is_active?: unknown }): Profile["status"] {
+  return (
+    (row.status as Profile["status"] | null) ??
+    ((row.is_active as boolean) ? "active" : "deactivated")
+  );
+}
+
+async function loadProfilePg(userId: string): Promise<Profile | null> {
+  const rows = await pgQuery<Record<string, unknown>>(
+    "select id, email, name, role, status, is_active, created_at from profiles where id = $1",
+    [userId],
+  );
+  if (rows.length === 0) return null;
+  const data = rows[0];
+  const tp = await pgQuery<{ phone: string | null; intro_text: string | null }>(
+    "select phone, intro_text from trainee_profile where id = $1",
+    [userId],
+  );
+  return {
+    userId: data.id as string,
+    email: data.email as string,
+    phone: tp[0]?.phone ?? null,
+    name: data.name as string,
+    role: data.role as Profile["role"],
+    status: statusOf(data),
+    hasIntro: !!(tp[0]?.intro_text && tp[0].intro_text.trim().length > 0),
+    createdAt: new Date(data.created_at as string).toISOString(),
+  };
+}
+
+async function createProfilePg(row: {
+  userId: string;
+  email: string;
+  name: string;
+  role: "coach" | "trainee";
+}): Promise<Profile> {
+  // Ensure the auth.users stub row exists (profiles.id FKs to it).
+  await pgQuery(
+    "insert into auth.users (id, email) values ($1, $2) on conflict (id) do nothing",
+    [row.userId, row.email],
+  );
+  const rows = await pgQuery<Record<string, unknown>>(
+    `insert into profiles (id, email, name, role, is_active)
+       values ($1, $2, $3, $4, true)
+       returning id, email, name, role, status, is_active, created_at`,
+    [row.userId, row.email, row.name, row.role],
+  );
+  const data = rows[0];
+  return {
+    userId: data.id as string,
+    email: data.email as string,
+    phone: null,
+    name: data.name as string,
+    role: data.role as Profile["role"],
+    status: statusOf(data),
+    hasIntro: false,
+    createdAt: new Date(data.created_at as string).toISOString(),
+  };
+}
+
 export async function loadProfile(userId: string): Promise<Profile | null> {
+  if (isPgDriver()) return loadProfilePg(userId);
   const db = admin();
   const { data, error } = await db
     .from("profiles")
@@ -58,6 +120,7 @@ export async function createProfile(row: {
   name: string;
   role: "coach" | "trainee";
 }): Promise<Profile> {
+  if (isPgDriver()) return createProfilePg(row);
   const { data, error } = await admin()
     .from("profiles")
     .insert({

--- a/src/lib/pg/__tests__/dev-auth.test.ts
+++ b/src/lib/pg/__tests__/dev-auth.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { signDevToken, verifyDevToken } from "../dev-auth";
+
+beforeAll(() => {
+  process.env.DEV_JWT_SECRET = "test-secret-at-least-thirty-two-characters!";
+});
+
+describe("dev-auth token roundtrip", () => {
+  it("signs and verifies a token, returning userId + email", () => {
+    const token = signDevToken({
+      sub: "11111111-1111-1111-1111-111111111111",
+      email: "coach@example.com",
+      role: "coach",
+    });
+    const session = verifyDevToken(token);
+    expect(session).toEqual({
+      userId: "11111111-1111-1111-1111-111111111111",
+      email: "coach@example.com",
+    });
+  });
+
+  it("rejects a garbage token", () => {
+    expect(verifyDevToken("not-a-jwt")).toBeNull();
+  });
+
+  it("rejects a token signed with a different secret", () => {
+    const token = signDevToken({ sub: "abc", email: "x@y.z" });
+    process.env.DEV_JWT_SECRET = "a-completely-different-secret-32-chars!!";
+    expect(verifyDevToken(token)).toBeNull();
+    process.env.DEV_JWT_SECRET = "test-secret-at-least-thirty-two-characters!";
+  });
+});

--- a/src/lib/pg/auth-service.ts
+++ b/src/lib/pg/auth-service.ts
@@ -1,0 +1,81 @@
+import { AuthService } from "@/lib/services/auth";
+import { Profile, UserRole } from "@/lib/types";
+import { pgQuery } from "./client";
+
+/**
+ * Native-Postgres AuthService (local dev). Per-request identity is resolved by
+ * require.ts via the JWT + loadProfile, so getCurrentUser() is unused here
+ * (returns null, like the mock). This exposes the coach-side trainee CRUD.
+ */
+export class PgAuthService implements AuthService {
+  async getCurrentUser(): Promise<Profile | null> {
+    return null;
+  }
+
+  async signOut(): Promise<void> {
+    /* no-op: dev tokens are stateless */
+  }
+
+  async getTrainees(): Promise<Profile[]> {
+    const rows = await pgQuery<Record<string, unknown>>(
+      "select * from profiles where role = 'trainee' order by name",
+    );
+    return rows.map((p) => this.mapProfile(p));
+  }
+
+  async deleteTrainee(id: string): Promise<void> {
+    const rows = await pgQuery<{ is_active: boolean }>(
+      "select is_active from profiles where id = $1",
+      [id],
+    );
+    if (rows.length === 0) throw new Error("Trainee not found");
+    if (rows[0].is_active) throw new Error("Cannot delete active trainee");
+    await pgQuery("delete from profiles where id = $1", [id]);
+  }
+
+  async updateTrainee(
+    id: string,
+    updates: {
+      isRecurring?: boolean;
+      preferredDay?: number | null;
+      preferredTime?: string | null;
+      isActive?: boolean;
+      name?: string;
+    },
+  ): Promise<Profile> {
+    const sets: string[] = [];
+    const params: unknown[] = [];
+    if (updates.isRecurring !== undefined) sets.push(`is_recurring = $${params.push(updates.isRecurring)}`);
+    if (updates.preferredDay !== undefined) sets.push(`preferred_day = $${params.push(updates.preferredDay)}`);
+    if (updates.preferredTime !== undefined) sets.push(`preferred_time = $${params.push(updates.preferredTime)}`);
+    if (updates.isActive !== undefined) sets.push(`is_active = $${params.push(updates.isActive)}`);
+    if (updates.name !== undefined) sets.push(`name = $${params.push(updates.name)}`);
+    if (sets.length === 0) {
+      const cur = await pgQuery<Record<string, unknown>>("select * from profiles where id = $1", [id]);
+      if (cur.length === 0) throw new Error("Trainee not found");
+      return this.mapProfile(cur[0]);
+    }
+    params.push(id);
+    const rows = await pgQuery<Record<string, unknown>>(
+      `update profiles set ${sets.join(", ")} where id = $${params.length} returning *`,
+      params,
+    );
+    if (rows.length === 0) throw new Error("Trainee not found");
+    return this.mapProfile(rows[0]);
+  }
+
+  private mapProfile(row: Record<string, unknown>): Profile & { email?: string | null; status?: string } {
+    return {
+      id: row.id as string,
+      name: row.name as string,
+      role: row.role as UserRole,
+      isRecurring: (row.is_recurring as boolean) ?? false,
+      preferredDay: row.preferred_day as number | null,
+      preferredTime: row.preferred_time ? String(row.preferred_time).slice(0, 5) : null,
+      isActive: (row.is_active as boolean) ?? true,
+      createdAt: new Date(row.created_at as string),
+      email: (row.email as string | null) ?? null,
+      status: (row.status as string) ?? ((row.is_active as boolean) ? "active" : "deactivated"),
+    };
+  }
+}

--- a/src/lib/pg/booking-store.ts
+++ b/src/lib/pg/booking-store.ts
@@ -1,0 +1,301 @@
+import { Booking, Slot, EditLog, ChangeRequest, ReminderKind } from "@/lib/types";
+import { BookingStore, REMINDER_DB_COLUMN } from "@/lib/services/booking-store";
+import { israelSlotToUTC } from "@/lib/services/israel-time";
+import { pgQuery } from "./client";
+
+/**
+ * Native-Postgres BookingStore (local dev, DB_DRIVER=pg). Mirrors
+ * SupabaseBookingStore's behavior and row→domain mapping, but issues SQL
+ * directly via node-postgres. The pool connects as DB owner, so RLS is bypassed
+ * (same effect as the cloud service-role key).
+ */
+export class PgBookingStore implements BookingStore {
+  // --- Slot methods ---
+
+  async getSlot(slotId: string): Promise<Slot | undefined> {
+    const slots = await pgQuery("select * from slots where id = $1", [slotId]);
+    if (slots.length === 0) return undefined;
+    const counts = await pgQuery<{ n: string }>(
+      "select count(*)::int as n from bookings where slot_id = $1 and status = 'confirmed'",
+      [slotId],
+    );
+    return this.mapSlot(slots[0], Number(counts[0]?.n ?? 0));
+  }
+
+  async updateSlot(slot: Slot): Promise<void> {
+    const params: unknown[] = [slot.capacity, slot.lockoutOverride, (slot.version ?? 0) + 1, slot.id];
+    let sql =
+      "update slots set capacity = $1, lockout_override = $2, version = $3 where id = $4";
+    if (slot.version !== undefined) {
+      sql += " and version = $5";
+      params.push(slot.version);
+    }
+    const rows = await pgQuery(sql + " returning id", params);
+    if (rows.length === 0) throw new Error("Slot was modified by another request");
+  }
+
+  async upsertSlot(slot: Slot): Promise<void> {
+    await pgQuery(
+      `insert into slots (id, date, start_time, capacity, lockout_override)
+         values (coalesce($1, gen_random_uuid()), $2, $3, $4, $5)
+         on conflict (date, start_time) do update
+           set capacity = excluded.capacity, lockout_override = excluded.lockout_override`,
+      [slot.id || null, slot.date, slot.startTime, slot.capacity, slot.lockoutOverride],
+    );
+  }
+
+  async getAllSlotsForDate(date: string): Promise<Slot[]> {
+    const slots = await pgQuery("select * from slots where date = $1", [date]);
+    if (slots.length === 0) return [];
+    const ids = slots.map((s) => (s as { id: string }).id);
+    const counts = await pgQuery<{ slot_id: string; n: string }>(
+      `select slot_id, count(*)::int as n from bookings
+         where slot_id = any($1) and status = 'confirmed' group by slot_id`,
+      [ids],
+    );
+    const countMap = new Map(counts.map((c) => [c.slot_id, Number(c.n)]));
+    return slots.map((s) => this.mapSlot(s, countMap.get((s as { id: string }).id) ?? 0));
+  }
+
+  // --- Booking methods ---
+
+  async addBooking(booking: Booking): Promise<void> {
+    await pgQuery(
+      `insert into bookings (id, slot_id, trainee_id, google_event_id, is_auto_booked, status)
+         values (coalesce($1, gen_random_uuid()), $2, $3, $4, $5, $6)`,
+      [
+        booking.id || null,
+        booking.slotId,
+        booking.traineeId,
+        booking.googleEventId ?? null,
+        booking.isAutoBooked,
+        booking.status,
+      ],
+    );
+  }
+
+  async getBooking(bookingId: string): Promise<Booking | undefined> {
+    const rows = await pgQuery("select * from bookings where id = $1", [bookingId]);
+    return rows[0] ? this.mapBooking(rows[0]) : undefined;
+  }
+
+  async updateBooking(booking: Booking): Promise<void> {
+    await pgQuery(
+      `update bookings set status = $1, google_event_id = $2, is_auto_booked = $3 where id = $4`,
+      [booking.status, booking.googleEventId ?? null, booking.isAutoBooked, booking.id],
+    );
+  }
+
+  async getConfirmedBookingsForSlot(slotId: string): Promise<Booking[]> {
+    const rows = await pgQuery(
+      "select * from bookings where slot_id = $1 and status = 'confirmed'",
+      [slotId],
+    );
+    return rows.map((b) => this.mapBooking(b));
+  }
+
+  async getTraineeBookings(traineeId: string): Promise<Booking[]> {
+    const rows = await pgQuery(
+      "select * from bookings where trainee_id = $1 and status = 'confirmed'",
+      [traineeId],
+    );
+    return rows.map((b) => this.mapBooking(b));
+  }
+
+  async getTraineeBookingsForWeek(traineeId: string, weekStart: string): Promise<Booking[]> {
+    const start = new Date(weekStart + "T00:00:00Z");
+    const end = new Date(start);
+    end.setDate(end.getDate() + 6);
+    const endStr = end.toISOString().slice(0, 10);
+    const rows = await pgQuery(
+      `select b.* from bookings b
+         join slots s on s.id = b.slot_id
+         where b.trainee_id = $1 and b.status = 'confirmed'
+           and s.date >= $2 and s.date <= $3`,
+      [traineeId, weekStart, endStr],
+    );
+    return rows.map((b) => this.mapBooking(b));
+  }
+
+  async getAllBookings(): Promise<Booking[]> {
+    const rows = await pgQuery("select * from bookings order by created_at desc");
+    return rows.map((b) => this.mapBooking(b));
+  }
+
+  // --- Edit log methods ---
+
+  async getEditLog(traineeId: string, weekStart: string): Promise<EditLog | undefined> {
+    const rows = await pgQuery(
+      "select * from edit_log where trainee_id = $1 and week_start = $2",
+      [traineeId, weekStart],
+    );
+    return rows[0] ? this.mapEditLog(rows[0]) : undefined;
+  }
+
+  async incrementEditCount(traineeId: string, weekStart: string): Promise<void> {
+    await pgQuery(
+      `insert into edit_log (trainee_id, week_start, edit_count) values ($1, $2, 1)
+         on conflict (trainee_id, week_start) do update
+           set edit_count = edit_log.edit_count + 1`,
+      [traineeId, weekStart],
+    );
+  }
+
+  async resetEditCount(traineeId: string, weekStart: string): Promise<void> {
+    await pgQuery(
+      "update edit_log set edit_count = 0 where trainee_id = $1 and week_start = $2",
+      [traineeId, weekStart],
+    );
+  }
+
+  async getRemindersDue(
+    kind: ReminderKind,
+    windowStartUtc: Date,
+    windowEndUtc: Date,
+  ): Promise<Array<{ booking: Booking; slot: Slot }>> {
+    const col = REMINDER_DB_COLUMN[kind];
+    const rows = await pgQuery(
+      `select b.*, row_to_json(s) as slot from bookings b
+         join slots s on s.id = b.slot_id
+         where b.status = 'confirmed' and b.${col} is null`,
+    );
+    const startMs = windowStartUtc.getTime();
+    const endMs = windowEndUtc.getTime();
+    const out: Array<{ booking: Booking; slot: Slot }> = [];
+    for (const row of rows) {
+      const slotRow = (row as Record<string, unknown>).slot as Record<string, unknown>;
+      if (!slotRow) continue;
+      const slot = this.mapSlot(slotRow, 0);
+      const slotMs = israelSlotToUTC(slot.date, slot.startTime).getTime();
+      if (slotMs < startMs || slotMs >= endMs) continue;
+      out.push({ booking: this.mapBooking(row), slot });
+    }
+    return out;
+  }
+
+  async markReminderSent(bookingId: string, kind: ReminderKind, sentAt: Date): Promise<void> {
+    const col = REMINDER_DB_COLUMN[kind];
+    await pgQuery(
+      `update bookings set ${col} = $1 where id = $2 and ${col} is null`,
+      [sentAt.toISOString(), bookingId],
+    );
+  }
+
+  // --- Phase 15: change-request methods ---
+
+  async createChangeRequest(input: {
+    bookingId: string;
+    requestedNewSlotId: string | null;
+    reason: string;
+  }): Promise<ChangeRequest> {
+    const rows = await pgQuery(
+      `insert into booking_change_request (booking_id, requested_new_slot_id, reason)
+         values ($1, $2, $3) returning *`,
+      [input.bookingId, input.requestedNewSlotId, input.reason],
+    );
+    return this.mapChangeRequest(rows[0]);
+  }
+
+  async getChangeRequest(id: string): Promise<ChangeRequest | undefined> {
+    const rows = await pgQuery("select * from booking_change_request where id = $1", [id]);
+    return rows[0] ? this.mapChangeRequest(rows[0]) : undefined;
+  }
+
+  async getPendingRequestForBooking(bookingId: string): Promise<ChangeRequest | undefined> {
+    const rows = await pgQuery(
+      "select * from booking_change_request where booking_id = $1 and status = 'pending'",
+      [bookingId],
+    );
+    return rows[0] ? this.mapChangeRequest(rows[0]) : undefined;
+  }
+
+  async listPendingRequests(): Promise<ChangeRequest[]> {
+    const rows = await pgQuery(
+      "select * from booking_change_request where status = 'pending' order by requested_at asc",
+    );
+    return rows.map((r) => this.mapChangeRequest(r));
+  }
+
+  async updateChangeRequest(
+    id: string,
+    patch: Partial<{
+      status: ChangeRequest["status"];
+      decisionNote: string | null;
+      decidedAt: Date | null;
+      decidedBy: string | null;
+    }>,
+  ): Promise<void> {
+    const sets: string[] = [];
+    const params: unknown[] = [];
+    if (patch.status !== undefined) sets.push(`status = $${params.push(patch.status)}`);
+    if (patch.decisionNote !== undefined)
+      sets.push(`decision_note = $${params.push(patch.decisionNote)}`);
+    if (patch.decidedAt !== undefined)
+      sets.push(`decided_at = $${params.push(patch.decidedAt ? patch.decidedAt.toISOString() : null)}`);
+    if (patch.decidedBy !== undefined) sets.push(`decided_by = $${params.push(patch.decidedBy)}`);
+    if (sets.length === 0) return;
+    params.push(id);
+    await pgQuery(
+      `update booking_change_request set ${sets.join(", ")} where id = $${params.length}`,
+      params,
+    );
+  }
+
+  // --- Mappers (identical to SupabaseBookingStore) ---
+
+  private mapSlot(row: Record<string, unknown>, currentBookings: number): Slot {
+    return {
+      id: row.id as string,
+      date: String(row.date).slice(0, 10),
+      startTime: String(row.start_time).slice(0, 5),
+      capacity: row.capacity as number,
+      lockoutOverride: row.lockout_override as boolean,
+      currentBookings,
+      version: row.version as number | undefined,
+    };
+  }
+
+  private mapBooking(row: Record<string, unknown>): Booking {
+    return {
+      id: row.id as string,
+      slotId: row.slot_id as string,
+      traineeId: row.trainee_id as string,
+      googleEventId: (row.google_event_id as string) ?? null,
+      isAutoBooked: row.is_auto_booked as boolean,
+      status: row.status as Booking["status"],
+      createdAt: new Date(row.created_at as string),
+      reminder24hSentAt: row.reminder_24h_sent_at
+        ? new Date(row.reminder_24h_sent_at as string)
+        : null,
+      reminder2hSentAt: row.reminder_2h_sent_at
+        ? new Date(row.reminder_2h_sent_at as string)
+        : null,
+      postSessionPromptSentAt: row.postsession_prompt_sent_at
+        ? new Date(row.postsession_prompt_sent_at as string)
+        : null,
+    };
+  }
+
+  private mapEditLog(row: Record<string, unknown>): EditLog {
+    return {
+      id: row.id as string,
+      traineeId: row.trainee_id as string,
+      weekStart: String(row.week_start).slice(0, 10),
+      editCount: row.edit_count as number,
+    };
+  }
+
+  private mapChangeRequest(row: Record<string, unknown>): ChangeRequest {
+    return {
+      id: row.id as string,
+      bookingId: row.booking_id as string,
+      requestedNewSlotId: (row.requested_new_slot_id as string) ?? null,
+      reason: row.reason as string,
+      status: row.status as ChangeRequest["status"],
+      decisionNote: (row.decision_note as string) ?? null,
+      requestedAt: new Date(row.requested_at as string),
+      decidedAt: row.decided_at ? new Date(row.decided_at as string) : null,
+      decidedBy: (row.decided_by as string) ?? null,
+    };
+  }
+}

--- a/src/lib/pg/client.ts
+++ b/src/lib/pg/client.ts
@@ -1,4 +1,11 @@
-import { Pool } from "pg";
+import { Pool, types } from "pg";
+
+// node-postgres parses DATE (oid 1082) into a JS Date at local midnight, which
+// then stringifies to "Thu Jun 01 2026 …". Supabase returns plain "2026-06-01"
+// strings, and the domain mappers expect that. Keep DATE as its raw string so
+// pg and Supabase behave identically. (TIME is already returned as a string;
+// timestamps stay Date objects, which the mappers wrap in `new Date(...)`.)
+types.setTypeParser(1082, (v) => v);
 
 /**
  * Native-Postgres connection pool for local development (no Docker, no

--- a/src/lib/pg/client.ts
+++ b/src/lib/pg/client.ts
@@ -1,0 +1,49 @@
+import { Pool } from "pg";
+
+/**
+ * Native-Postgres connection pool for local development (no Docker, no
+ * Supabase services). Selected when `DB_DRIVER=pg`; the cloud Supabase path
+ * stays the default so production is untouched.
+ *
+ * Connection comes from `DATABASE_URL`, e.g.
+ *   postgres://postgres:postgres@localhost:5432/velofit_dev
+ *
+ * The pool connects as the DB owner, which bypasses RLS — so the dev schema
+ * can keep the migration RLS policies without them blocking server queries
+ * (same effect as Supabase's service-role key).
+ */
+let pool: Pool | null = null;
+
+export function isPgDriver(): boolean {
+  return process.env.DB_DRIVER === "pg";
+}
+
+export function getPgPool(): Pool {
+  if (!pool) {
+    const connectionString = process.env.DATABASE_URL;
+    if (!connectionString) {
+      throw new Error(
+        "DATABASE_URL is required when DB_DRIVER=pg (e.g. postgres://postgres:postgres@localhost:5432/velofit_dev)",
+      );
+    }
+    pool = new Pool({ connectionString, max: 10 });
+  }
+  return pool;
+}
+
+/** Convenience query helper returning rows typed as T. */
+export async function pgQuery<T = Record<string, unknown>>(
+  text: string,
+  params?: unknown[],
+): Promise<T[]> {
+  const res = await getPgPool().query(text, params as never[]);
+  return res.rows as T[];
+}
+
+/** Closes the pool (used by scripts so the process can exit). */
+export async function closePgPool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}

--- a/src/lib/pg/dev-auth.ts
+++ b/src/lib/pg/dev-auth.ts
@@ -1,0 +1,42 @@
+import jwt from "jsonwebtoken";
+
+/**
+ * Local dev-auth: mint & verify our own HS256 JWTs so the app needs no GoTrue
+ * when running on native Postgres (`DB_DRIVER=pg`). NOT for production — the
+ * cloud path still uses Supabase Auth.
+ *
+ * The token mirrors the two fields the app reads from a Supabase session:
+ * `sub` (user id) and `email`.
+ */
+function secret(): string {
+  return (
+    process.env.DEV_JWT_SECRET ||
+    "velofit-local-dev-secret-change-me-min-32-chars"
+  );
+}
+
+export interface DevTokenInput {
+  sub: string;
+  email: string;
+  role?: string;
+}
+
+export function signDevToken(input: DevTokenInput): string {
+  return jwt.sign(
+    { email: input.email, role: input.role ?? "authenticated" },
+    secret(),
+    { subject: input.sub, expiresIn: "30d" },
+  );
+}
+
+export function verifyDevToken(
+  token: string,
+): { userId: string; email: string } | null {
+  try {
+    const decoded = jwt.verify(token, secret()) as jwt.JwtPayload;
+    if (!decoded.sub || !decoded.email) return null;
+    return { userId: String(decoded.sub), email: String(decoded.email) };
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/pg/progress-store.ts
+++ b/src/lib/pg/progress-store.ts
@@ -1,0 +1,113 @@
+import type {
+  MeasurementLog,
+  MeasurementInput,
+  SessionLog,
+  SessionLogInput,
+} from "@/lib/types";
+import { ProgressStore, validateMeasurementInput } from "@/lib/services/progress-store";
+import { pgQuery } from "./client";
+
+/** Native-Postgres ProgressStore (local dev). Mirrors SupabaseProgressStore. */
+export class PgProgressStore implements ProgressStore {
+  async createMeasurement(traineeId: string, input: MeasurementInput): Promise<MeasurementLog> {
+    validateMeasurementInput(input);
+    const rows = await pgQuery<Record<string, unknown>>(
+      `insert into measurement_logs (trainee_id, weight_kg, metrics, photo_url, note, logged_at)
+         values ($1, $2, $3, $4, $5, coalesce($6, now()))
+         returning *`,
+      [
+        traineeId,
+        input.weightKg ?? null,
+        input.metrics ? JSON.stringify(input.metrics) : null,
+        input.photoUrl ?? null,
+        input.note?.trim() ? input.note.trim() : null,
+        input.loggedAt ? input.loggedAt.toISOString() : null,
+      ],
+    );
+    return this.mapMeasurement(rows[0]);
+  }
+
+  async listMeasurements(
+    traineeId: string,
+    opts: { limit?: number; sinceDays?: number } = {},
+  ): Promise<MeasurementLog[]> {
+    const params: unknown[] = [traineeId];
+    let sql =
+      "select * from measurement_logs where trainee_id = $1";
+    if (opts.sinceDays) {
+      const cutoff = new Date(Date.now() - opts.sinceDays * 86_400_000).toISOString();
+      sql += ` and logged_at >= $${params.push(cutoff)}`;
+    }
+    sql += " order by logged_at desc";
+    if (opts.limit) sql += ` limit $${params.push(opts.limit)}`;
+    const rows = await pgQuery<Record<string, unknown>>(sql, params);
+    return rows.map((r) => this.mapMeasurement(r));
+  }
+
+  async getLastMeasurement(traineeId: string): Promise<MeasurementLog | undefined> {
+    const rows = await this.listMeasurements(traineeId, { limit: 1 });
+    return rows[0];
+  }
+
+  async upsertSessionLog(bookingId: string, input: SessionLogInput): Promise<SessionLog> {
+    const rows = await pgQuery<Record<string, unknown>>(
+      `insert into session_logs (booking_id, feedback, coach_notes, updated_at)
+         values ($1, $2, $3, now())
+         on conflict (booking_id) do update set
+           feedback = coalesce($2, session_logs.feedback),
+           coach_notes = coalesce($3, session_logs.coach_notes),
+           updated_at = now()
+         returning *`,
+      [
+        bookingId,
+        input.feedback !== undefined ? JSON.stringify(input.feedback) : null,
+        input.coachNotes !== undefined ? input.coachNotes : null,
+      ],
+    );
+    return this.mapSessionLog(rows[0]);
+  }
+
+  async getSessionLog(bookingId: string): Promise<SessionLog | undefined> {
+    const rows = await pgQuery<Record<string, unknown>>(
+      "select * from session_logs where booking_id = $1",
+      [bookingId],
+    );
+    return rows[0] ? this.mapSessionLog(rows[0]) : undefined;
+  }
+
+  async listSessionLogsForTrainee(
+    traineeId: string,
+    opts: { limit?: number } = {},
+  ): Promise<SessionLog[]> {
+    const params: unknown[] = [traineeId];
+    let sql = `select sl.* from session_logs sl
+        join bookings b on b.id = sl.booking_id
+        where b.trainee_id = $1
+        order by sl.updated_at desc`;
+    if (opts.limit) sql += ` limit $${params.push(opts.limit)}`;
+    const rows = await pgQuery<Record<string, unknown>>(sql, params);
+    return rows.map((r) => this.mapSessionLog(r));
+  }
+
+  private mapMeasurement(row: Record<string, unknown>): MeasurementLog {
+    return {
+      id: row.id as string,
+      traineeId: row.trainee_id as string,
+      loggedAt: new Date(row.logged_at as string),
+      weightKg: row.weight_kg != null ? Number(row.weight_kg) : null,
+      metrics: (row.metrics as Record<string, unknown> | null) ?? null,
+      photoUrl: (row.photo_url as string) ?? null,
+      note: (row.note as string) ?? null,
+    };
+  }
+
+  private mapSessionLog(row: Record<string, unknown>): SessionLog {
+    return {
+      bookingId: row.booking_id as string,
+      feedback: (row.feedback as Record<string, unknown> | null) ?? null,
+      coachNotes: (row.coach_notes as string) ?? null,
+      createdAt: new Date(row.created_at as string),
+      updatedAt: new Date(row.updated_at as string),
+    };
+  }
+}

--- a/src/lib/services/coach-info-repo.ts
+++ b/src/lib/services/coach-info-repo.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
+import { isPgDriver, pgQuery } from "@/lib/pg/client";
 
 export type CoachInfo = {
   name: string;
@@ -24,6 +25,22 @@ function admin() {
 }
 
 export async function getCoachInfo(): Promise<CoachInfo | null> {
+  if (isPgDriver()) {
+    const coach = await pgQuery<{ name: string }>(
+      "select name from profiles where role = 'coach' order by created_at limit 1",
+    );
+    if (coach.length === 0) return null;
+    const s = await pgQuery<Record<string, unknown>>(
+      "select contact_phone, bio, specialty, years_experience from coach_settings limit 1",
+    );
+    return {
+      name: coach[0].name,
+      contactPhone: (s[0]?.contact_phone as string | null) ?? null,
+      bio: (s[0]?.bio as string | null) ?? null,
+      specialty: (s[0]?.specialty as string | null) ?? null,
+      yearsExperience: (s[0]?.years_experience as number | null) ?? null,
+    };
+  }
   const db = admin();
   const { data: coach } = await db
     .from("profiles")
@@ -49,6 +66,14 @@ export async function getCoachInfo(): Promise<CoachInfo | null> {
 }
 
 export async function updateCoachContactPhone(coachId: string, phone: string): Promise<void> {
+  if (isPgDriver()) {
+    await pgQuery(
+      `insert into coach_settings (id, contact_phone) values ($1, $2)
+         on conflict (id) do update set contact_phone = excluded.contact_phone`,
+      [coachId, phone],
+    );
+    return;
+  }
   const db = admin();
   // coach_settings is a single-row table; upsert by id (matching profile id)
   const { error } = await db
@@ -58,6 +83,30 @@ export async function updateCoachContactPhone(coachId: string, phone: string): P
 }
 
 export async function updateCoachInfo(coachId: string, patch: CoachInfoPatch): Promise<void> {
+  if (isPgDriver()) {
+    const cols: string[] = ["id"];
+    const vals: unknown[] = [coachId];
+    const ph: string[] = ["$1"];
+    const add = (col: string, v: unknown) => {
+      cols.push(col);
+      vals.push(v);
+      ph.push(`$${vals.length}`);
+    };
+    if (patch.contactPhone !== undefined) add("contact_phone", patch.contactPhone);
+    if (patch.bio !== undefined) add("bio", patch.bio);
+    if (patch.specialty !== undefined) add("specialty", patch.specialty);
+    if (patch.yearsExperience !== undefined) add("years_experience", patch.yearsExperience);
+    const updates = cols
+      .slice(1)
+      .map((c) => `${c} = excluded.${c}`)
+      .join(", ");
+    await pgQuery(
+      `insert into coach_settings (${cols.join(", ")}) values (${ph.join(", ")})
+         on conflict (id) do update set ${updates || "id = excluded.id"}`,
+      vals,
+    );
+    return;
+  }
   const db = admin();
   const dbPatch: Record<string, unknown> = { id: coachId };
   if (patch.contactPhone !== undefined) dbPatch.contact_phone = patch.contactPhone;

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -13,6 +13,10 @@ import { SupabaseBookingStore } from "@/lib/supabase/booking-store";
 import { SupabaseProgressStore } from "@/lib/supabase/progress-store";
 import { SupabaseAuthService, MockAuthService } from "@/lib/supabase/auth-service";
 import { getSupabaseClient, getSupabaseAdminClient } from "@/lib/supabase/client";
+import { isPgDriver } from "@/lib/pg/client";
+import { PgBookingStore } from "@/lib/pg/booking-store";
+import { PgProgressStore } from "@/lib/pg/progress-store";
+import { PgAuthService } from "@/lib/pg/auth-service";
 
 function isFullMock() {
   return process.env.MOCK_SERVICES === "true";
@@ -56,7 +60,9 @@ export function getAuthService(): AuthService {
   if (!authService) {
     authService = isFullMock()
       ? new MockAuthService()
-      : new SupabaseAuthService(getSupabaseClient(), getSupabaseAdminClient());
+      : isPgDriver()
+        ? new PgAuthService()
+        : new SupabaseAuthService(getSupabaseClient(), getSupabaseAdminClient());
   }
   return authService;
 }
@@ -65,7 +71,9 @@ export function getBookingStore(): BookingStore {
   if (!bookingStore) {
     bookingStore = isFullMock()
       ? new MockBookingStore()
-      : new SupabaseBookingStore(getSupabaseAdminClient());
+      : isPgDriver()
+        ? new PgBookingStore()
+        : new SupabaseBookingStore(getSupabaseAdminClient());
   }
   return bookingStore;
 }
@@ -81,7 +89,9 @@ export function getProgressStore(): ProgressStore {
   if (!progressStore) {
     progressStore = isFullMock()
       ? new MockProgressStore()
-      : new SupabaseProgressStore(getSupabaseAdminClient());
+      : isPgDriver()
+        ? new PgProgressStore()
+        : new SupabaseProgressStore(getSupabaseAdminClient());
   }
   return progressStore;
 }

--- a/src/lib/services/jwt-session.ts
+++ b/src/lib/services/jwt-session.ts
@@ -1,5 +1,7 @@
 import { NextRequest } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { isPgDriver } from "@/lib/pg/client";
+import { verifyDevToken } from "@/lib/pg/dev-auth";
 
 export type JwtSession = { userId: string; email: string };
 
@@ -7,6 +9,9 @@ export async function getJwtSession(req: NextRequest): Promise<JwtSession | null
   const authHeader = req.headers.get("authorization");
   if (!authHeader?.startsWith("Bearer ")) return null;
   const jwt = authHeader.slice(7);
+
+  // Local dev on native Postgres: verify our own HS256 token (no GoTrue).
+  if (isPgDriver()) return verifyDevToken(jwt);
 
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,

--- a/src/lib/services/notes-repo.ts
+++ b/src/lib/services/notes-repo.ts
@@ -1,5 +1,6 @@
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { CoachNote } from "@/lib/types";
+import { isPgDriver, pgQuery } from "@/lib/pg/client";
 
 function admin(): SupabaseClient {
   return createClient(
@@ -21,6 +22,13 @@ function mapNote(row: Record<string, unknown>): CoachNote {
 }
 
 export async function listNotesForTrainee(traineeId: string): Promise<CoachNote[]> {
+  if (isPgDriver()) {
+    const rows = await pgQuery<Record<string, unknown>>(
+      "select * from coach_notes where trainee_id = $1 order by created_at desc",
+      [traineeId],
+    );
+    return rows.map(mapNote);
+  }
   const { data, error } = await admin()
     .from("coach_notes")
     .select("*")
@@ -34,6 +42,14 @@ export async function listVisibleNotesForTrainee(
   traineeId: string,
   limit = 10
 ): Promise<CoachNote[]> {
+  if (isPgDriver()) {
+    const rows = await pgQuery<Record<string, unknown>>(
+      `select * from coach_notes where trainee_id = $1 and visible_to_trainee = true
+         order by created_at desc limit $2`,
+      [traineeId, limit],
+    );
+    return rows.map(mapNote);
+  }
   const { data, error } = await admin()
     .from("coach_notes")
     .select("*")
@@ -52,6 +68,14 @@ export async function createNote(input: {
 }): Promise<CoachNote> {
   const trimmed = input.body.trim();
   if (!trimmed) throw new Error("body required");
+  if (isPgDriver()) {
+    const rows = await pgQuery<Record<string, unknown>>(
+      `insert into coach_notes (trainee_id, body, visible_to_trainee)
+         values ($1, $2, $3) returning *`,
+      [input.traineeId, trimmed, input.visibleToTrainee],
+    );
+    return mapNote(rows[0]);
+  }
   const { data, error } = await admin()
     .from("coach_notes")
     .insert({
@@ -69,12 +93,27 @@ export async function updateNote(
   id: string,
   patch: { body?: string; visibleToTrainee?: boolean }
 ): Promise<CoachNote> {
-  const dbPatch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  let trimmedBody: string | undefined;
   if (patch.body !== undefined) {
-    const trimmed = patch.body.trim();
-    if (!trimmed) throw new Error("body cannot be empty");
-    dbPatch.body = trimmed;
+    trimmedBody = patch.body.trim();
+    if (!trimmedBody) throw new Error("body cannot be empty");
   }
+  if (isPgDriver()) {
+    const sets: string[] = ["updated_at = now()"];
+    const params: unknown[] = [];
+    if (trimmedBody !== undefined) sets.push(`body = $${params.push(trimmedBody)}`);
+    if (patch.visibleToTrainee !== undefined)
+      sets.push(`visible_to_trainee = $${params.push(patch.visibleToTrainee)}`);
+    params.push(id);
+    const rows = await pgQuery<Record<string, unknown>>(
+      `update coach_notes set ${sets.join(", ")} where id = $${params.length} returning *`,
+      params,
+    );
+    if (rows.length === 0) throw new Error("updateNote failed: not found");
+    return mapNote(rows[0]);
+  }
+  const dbPatch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (trimmedBody !== undefined) dbPatch.body = trimmedBody;
   if (patch.visibleToTrainee !== undefined) {
     dbPatch.visible_to_trainee = patch.visibleToTrainee;
   }
@@ -89,6 +128,10 @@ export async function updateNote(
 }
 
 export async function deleteNote(id: string): Promise<void> {
+  if (isPgDriver()) {
+    await pgQuery("delete from coach_notes where id = $1", [id]);
+    return;
+  }
   const { error } = await admin().from("coach_notes").delete().eq("id", id);
   if (error) throw new Error(`deleteNote failed: ${error.message}`);
 }

--- a/src/lib/services/trainee-invite.ts
+++ b/src/lib/services/trainee-invite.ts
@@ -1,4 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
+import { randomUUID } from "crypto";
+import { isPgDriver, pgQuery } from "@/lib/pg/client";
 
 export type InviteInput = {
   email: string;
@@ -24,14 +26,43 @@ function admin() {
 }
 
 /**
- * Create an *active* trainee (the invitation IS the approval — ADR-0004):
- * 1. Supabase Admin API sends an invite email (creates auth.users row).
- * 2. Upsert profiles row with status='active'. No coach approval step needed.
+ * Create an *active* trainee (the invitation IS the approval — ADR-0004).
  *
- * Self-signups (Google OAuth without an invite) land in status='pending' and
- * must go through the intro form + coach approval — see /api/me + /api/me/intro.
+ * Cloud: Supabase Admin API sends an invite email (creates auth.users) then
+ * upserts an active profile. Local pg dev: no GoTrue/email — create an
+ * auth.users stub row and the active profile directly so the coach's
+ * "add trainee" flow works offline.
  */
 export async function inviteTraineeByEmail(input: InviteInput): Promise<InvitedProfile> {
+  if (isPgDriver()) {
+    const existing = await pgQuery<{ id: string }>(
+      "select id from auth.users where email = $1",
+      [input.email],
+    );
+    const userId = existing[0]?.id ?? randomUUID();
+    if (!existing[0]) {
+      await pgQuery("insert into auth.users (id, email) values ($1, $2)", [userId, input.email]);
+    }
+    const rows = await pgQuery<InvitedProfile>(
+      `insert into profiles (id, email, name, role, status, is_active, is_recurring, preferred_day, preferred_time)
+         values ($1, $2, $3, 'trainee', 'active', true, $4, $5, $6)
+         on conflict (id) do update set
+           email = excluded.email, name = excluded.name, status = 'active', is_active = true,
+           is_recurring = excluded.is_recurring, preferred_day = excluded.preferred_day,
+           preferred_time = excluded.preferred_time
+         returning id, email, name, status`,
+      [
+        userId,
+        input.email,
+        input.name,
+        input.isRecurring ?? false,
+        input.preferredDay ?? null,
+        input.preferredTime ?? null,
+      ],
+    );
+    return rows[0];
+  }
+
   const db = admin();
 
   // 1. Invite via Supabase Auth — creates auth.users row + sends magic-link
@@ -68,6 +99,7 @@ export async function inviteTraineeByEmail(input: InviteInput): Promise<InvitedP
 
 /** Re-trigger Supabase invite email for a trainee already in 'pending' state. */
 export async function resendInvite(email: string): Promise<void> {
+  if (isPgDriver()) return; // no email service locally — no-op
   const { error } = await admin().auth.admin.inviteUserByEmail(email);
   if (error) throw new Error(`Resend failed: ${error.message}`);
 }

--- a/src/lib/services/trainee-profile-repo.ts
+++ b/src/lib/services/trainee-profile-repo.ts
@@ -1,4 +1,5 @@
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { isPgDriver, pgQuery } from "@/lib/pg/client";
 
 export type TraineeProfileFields = {
   phone: string | null;
@@ -45,6 +46,13 @@ function map(row: Record<string, unknown> | null): TraineeProfileFields {
 }
 
 export async function getTraineeProfile(userId: string): Promise<TraineeProfileFields> {
+  if (isPgDriver()) {
+    const rows = await pgQuery<Record<string, unknown>>(
+      "select * from trainee_profile where id = $1",
+      [userId],
+    );
+    return map(rows[0] ?? null);
+  }
   const { data } = await admin()
     .from("trainee_profile")
     .select("*")
@@ -68,6 +76,36 @@ export async function upsertTraineeProfile(
   userId: string,
   patch: TraineeProfilePatch
 ): Promise<TraineeProfileFields> {
+  if (isPgDriver()) {
+    const cols: string[] = ["id"];
+    const vals: unknown[] = [userId];
+    const ph: string[] = ["$1"];
+    const add = (col: string, v: unknown) => {
+      cols.push(col);
+      vals.push(v);
+      ph.push(`$${vals.length}`);
+    };
+    if (patch.phone !== undefined) add("phone", patch.phone);
+    if (patch.introText !== undefined) add("intro_text", patch.introText);
+    if (patch.photoUrl !== undefined) add("photo_url", patch.photoUrl);
+    if (patch.dateOfBirth !== undefined) add("date_of_birth", patch.dateOfBirth);
+    if (patch.heightCm !== undefined) add("height_cm", patch.heightCm);
+    if (patch.weightKg !== undefined) add("weight_kg", patch.weightKg);
+    if (patch.goals !== undefined) add("goals", patch.goals);
+    if (patch.medical !== undefined) add("medical", patch.medical);
+    const updates = cols
+      .slice(1)
+      .map((c) => `${c} = excluded.${c}`)
+      .concat("updated_at = now()")
+      .join(", ");
+    const rows = await pgQuery<Record<string, unknown>>(
+      `insert into trainee_profile (${cols.join(", ")}) values (${ph.join(", ")})
+         on conflict (id) do update set ${updates}
+         returning *`,
+      vals,
+    );
+    return map(rows[0]);
+  }
   const dbPatch: Record<string, unknown> = {
     id: userId,
     updated_at: new Date().toISOString(),


### PR DESCRIPTION
Adds a fast, no-Docker local-dev path on **native Postgres**, behind `DB_DRIVER=pg` (backend) and `PG_DEV` (mobile). Cloud Supabase stays the default — when the flags are unset nothing changes, and the 321 vitest / 159 flutter tests still pass.

## Why
Cloud Supabase round-trips made local iteration slow. The app uses Supabase HTTP services (Auth/PostgREST/Storage), so "just point at Postgres" wasn't possible — this ports the data layer + auth to talk to a local pg directly.

## What's included
- **Phase 0** — `src/lib/pg/client.ts` (Pool + `isPgDriver`, DATE type-parser fix); `db:pg:reset`.
- **Phase 1** — `scripts/pg/{bootstrap.sql,reset.ts}`: auth/storage stubs + replay the 18 migrations (skips the Storage-bucket one).
- **Phase 2** — dev auth: `/api/dev/login` mints HS256 tokens; `jwt-session` verifies them locally (no GoTrue).
- **Phase 3** — `Pg{Booking,Progress,Auth}` stores wired into the container; `loadProfile`/`createProfile`, coach-info, notes, trainee-invite, trainee-profile, and routes `me`/`me/intro`/`approve`/`reject` branch on `isPgDriver()`.
- **Phase 4** — `scripts/pg/seed.ts` (`db:pg:seed`): coach + 8 trainees + slots.
- **Phase 5** — mobile: `devSessionProvider` → `/api/dev/login`, `AuthedHttpClient` Bearer, `auth_gate`/dev-panel branch on `PG_DEV`.
- `docs/LOCAL_DEV.md` documents the whole flow.

## Verified end-to-end vs local pg
coach trainees list, trainee dashboard/slots, **booking write**, measurement→progress, notes, coach-info — all via `/api/dev/login` tokens.

## Limitations (documented)
No local Storage service → progress photos (#61) unavailable locally; sign-out in `PG_DEV` doesn't yet clear the dev session (hot-restart to switch users).